### PR TITLE
New Tiles Now Flicker

### DIFF
--- a/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButton.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButton.cs
@@ -23,12 +23,15 @@ public class ArtifactTileButton : MonoBehaviour
     public Sprite emptySprite;
     public ArtifactTileButtonAnimator buttonAnimator;
     public UIArtifact buttonManager;
+    public bool flickerNext = false;
+    private bool startsActive;
 
     private void Start()
     {
         islandSprite = buttonAnimator.sliderImage.sprite;
 
         myStile = SGrid.current.GetStile(islandId); // happens in SGrid.Awake()
+        startsActive = myStile.isTileActive;
         SetTileActive(myStile.isTileActive);
         SetPosition(myStile.x, myStile.y);
 
@@ -81,7 +84,11 @@ public class ArtifactTileButton : MonoBehaviour
         isTileActive = v;
         if (v)
         {
-            // animation?
+            Debug.Log(gameObject.name + " is active: " + gameObject.activeSelf);
+            if (!startsActive)
+            {
+                flickerNext = true;
+            }
             buttonAnimator.sliderImage.sprite = islandSprite;
         }
         else
@@ -104,5 +111,22 @@ public class ArtifactTileButton : MonoBehaviour
         {
             buttonAnimator.sliderImage.sprite = islandSprite;
         }
+    }
+
+    public void Flicker() {
+        StartCoroutine(NewButtonFlicker());
+    }
+
+    private IEnumerator NewButtonFlicker() {
+        flickerNext = false;
+        buttonAnimator.sliderImage.sprite = islandSprite;
+        yield return new WaitForSeconds(.5f);
+        buttonAnimator.sliderImage.sprite = emptySprite;
+        yield return new WaitForSeconds(.5f);
+        buttonAnimator.sliderImage.sprite = islandSprite;
+        yield return new WaitForSeconds(.5f);
+        buttonAnimator.sliderImage.sprite = emptySprite;
+        yield return new WaitForSeconds(.5f);
+        buttonAnimator.sliderImage.sprite = islandSprite;
     }
 }

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -218,4 +218,15 @@ public class UIArtifact : MonoBehaviour
             }
         }
     }
+
+    public void FlickerNewTiles()
+    {
+        foreach (ArtifactTileButton b in _instance.buttons)
+        {
+            if (b.flickerNext)
+            {
+                b.Flicker();
+            }
+        }
+    }
 }

--- a/Slider/Assets/Scripts/UI/UIManager.cs
+++ b/Slider/Assets/Scripts/UI/UIManager.cs
@@ -146,6 +146,7 @@ public class UIManager : MonoBehaviour
             Player.SetCanMove(false);
 
             artifactAnimator.SetBool("isVisible", true);
+            uiArtifact.FlickerNewTiles();
         }
         else
         {


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a coroutine to ArtifactTileButton.cs that flickers the tiles, as well as a method to start the coroutine. Currently the Tile flickers twice upon opening the Artifact, but that can be changed fairly easily. Added a method to UIArtifact.cs that checks if any tiles are new and then calls Flicker() if they are.

## Related Task
New Slider Effect

## How Has This Been Tested?
Have checked through all tiles in the village, as well as the two that I can currently find in the cave.
As far as I can tell, should not affect any other areas in the code, other than adding a possible less than a millisecond delay after opening the artifact menu, where it checks to see if any of the tiles are new.

## Screenshots (if appropriate):
