### PR TITLE
Queue Implemented

### DIFF
--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -7,17 +7,25 @@ public class UIArtifact : MonoBehaviour
     public ArtifactTileButton[] buttons;
     private ArtifactTileButton currentButton;
     private List<ArtifactTileButton> adjacentButtons = new List<ArtifactTileButton>();
+    private Queue<ArtifactTileButton> Queue;
 
     private static UIArtifact _instance;
     
     public void Awake()
     {
         _instance = this;
+        Queue = new Queue<ArtifactTileButton>();
     }
 
     public static UIArtifact GetInstance()
     {
         return _instance;
+    }
+
+    public void OnDisable()
+    {
+        Queue = new Queue<ArtifactTileButton>();
+        Debug.Log("Queue Cleared!");
     }
 
     public void DeselectCurrentButton()
@@ -38,13 +46,15 @@ public class UIArtifact : MonoBehaviour
     {
         // Check if on movement cooldown
         //if (SGrid.GetStile(button.islandId).isMoving)
-        if (button.isForcedDown)
+        if (currentButton != null && currentButton.isForcedDown && adjacentButtons.Contains(button))
         {
-            //Debug.Log("on cooldown!");
-            return;
+            //Debug.Log(currentButton.gameObject.name + " added to the queue!");
+            //Debug.Log(button.gameObject.name + " added to the Queue");
+            QueueAdd(currentButton, button);
+            DeselectCurrentButton();
         }
 
-        if (currentButton == button)
+        else if (currentButton == button)
         {
             DeselectCurrentButton();
         }
@@ -160,6 +170,7 @@ public class UIArtifact : MonoBehaviour
         yield return new WaitForSeconds(1);
         
         button.SetForcedPushedDown(false);
+        CheckQueue();
     }
 
     //public static void UpdatePushedDowns()
@@ -227,6 +238,23 @@ public class UIArtifact : MonoBehaviour
             {
                 b.Flicker();
             }
+        }
+    }
+
+    public void QueueAdd(ArtifactTileButton currentButton, ArtifactTileButton buttonEmpty)
+    {
+        Queue.Enqueue(currentButton);
+        Queue.Enqueue(buttonEmpty);
+    }
+
+    public void CheckQueue()
+    {
+        if (Queue.Count != 0)
+        {
+            ArtifactTileButton currentButton = Queue.Dequeue();
+            ArtifactTileButton emptyButton = Queue.Dequeue();
+            //Debug.Log("Swapping " + currentButton.gameObject.name + " with " + emptyButton.gameObject.name);
+            Swap(currentButton, emptyButton);
         }
     }
 }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently the Queue only works up to another move ahead, if any more wants to happen, we need to change how swap is implemented. I also deactivated the waterfall entrance until the bug is fixed, whatever it is.

## Related Task
Slider Animation Queue

## How Has This Been Tested?
I have only been able to find the bug with the waterfall entrance currently. Otherwise, I have tested it with the other entrances in the map, including all 3 cave exits, as well as just tested it with multiple tiles with or without the player on them.

## Screenshots (if appropriate):
