### PR TITLE
Queue Bug Fix, Artifact QOL, Various Refactoring and Commenting in SGrid and UIArtifact

### DIFF
--- a/Slider/Assets/Scripts/Sliders/Grid/SGrid.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/SGrid.cs
@@ -4,13 +4,14 @@ using UnityEngine;
 
 public class SGrid : MonoBehaviour
 {
+    //L: The grid the player is currently interacting with (only 1 active at a time)
     public static SGrid current { get; private set; }
 
     public class OnGridMoveArgs : System.EventArgs
     {
         public STile[,] grid;
     }
-    public static event System.EventHandler<OnGridMoveArgs> OnGridMove; // IMPORTANT: this is in the background -- you might be looking for SGridAnimator.OnTileMove
+    public static event System.EventHandler<OnGridMoveArgs> OnGridMove; // IMPORTANT: this is in the background -- you might be looking for SGridAnimator.OnSTileMove
 
     private STile[,] grid;
     private STile[,] altGrid;
@@ -25,9 +26,11 @@ public class SGrid : MonoBehaviour
     [SerializeField] private STile[] altStiles;
     [SerializeField] private SGridBackground[] bgGridTiles;
     [SerializeField] private SGridAnimator gridAnimator;
+    //L: This is the end goal for the slider puzzle, set in the inspector.
+    //It is derived from the order of tiles in the puzzle doc. (EX: 624897153 for the starting Village)
     [SerializeField] protected string targetGrid = "*********"; // format: 123456789 for  1 2 3
-                                                  //                        4 5 6
-                                                  //              (0, 0) -> 7 8 9
+                                                  //                                      4 5 6
+                                                  //              (0, 0) ->               7 8 9
 
     protected void Awake()
     {
@@ -58,6 +61,11 @@ public class SGrid : MonoBehaviour
         return bgGrid;
     }
 
+    /*L: Sets the position of STiles in the grid according to their ids.
+    Note: This updates all of the STiles according to the ids in the given array (unlike the other imp., which leaves the STiles in the same positions)
+    * 
+    * This is useful for reshuffling the grid.
+    */
     public void SetGrid(int[,] puzzle)
     {
         if (puzzle.Length != grid.Length)
@@ -97,7 +105,10 @@ public class SGrid : MonoBehaviour
         ArtifactTileButton.canComplete = true;
     }
 
-    //L: This is what initially loads in the grid if a grid is not already saved.
+    /*
+     * L: Populates the grid[,] array with the given stiles.
+     * This is what initially loads in the grid at the start of the scene if a grid is not already saved.
+     */
     private void SetGrid(STile[] stiles, STile[] altStiles=null)
     {
         if (stiles.Length != width * height)
@@ -156,6 +167,7 @@ public class SGrid : MonoBehaviour
         return s;
     }
 
+    //L: islandId is the id of the corresponding tile in the puzzle doc
     public STile GetStile(int islandId)
     {
         foreach (STile t in stiles)
@@ -174,6 +186,7 @@ public class SGrid : MonoBehaviour
         return null;
     }
 
+    //L: This mainly checks if any of the tiles involved in SMove 
     public bool CanMove(SMove move)
     {
         foreach (Vector4Int m in move.moves)
@@ -192,7 +205,7 @@ public class SGrid : MonoBehaviour
     }
 
     // Make sure to check if you CanMove() before moving
-    //L: Updates internal state (the grid) based on result of SMove. See Move in SGridAnimator for the actual moving of the tiles.
+    //L: Updates internal state (the grid[,]) based on result of SMove. See Move in SGridAnimator for the actual moving of the tiles.
     public void Move(SMove move)
     {
 
@@ -235,6 +248,7 @@ public class SGrid : MonoBehaviour
         GameManager.GetSaveSystem().SaveMissions(new Dictionary<string, bool>());
     }
 
+    //L: Used in the save system to load a grid as opposed to using SetGrid(STile[], STile[]) with default tiles positions.
     public virtual void LoadGrid() 
     { 
          //Debug.Log("Loading grid...");
@@ -273,6 +287,7 @@ public class SGrid : MonoBehaviour
         // temporary ?
         // GameObject.Find("Player").transform.position = GameManager.saveSystem.GetPlayerPos(myArea);
     }
+
 
     protected static void CheckCompletions(object sender, SGrid.OnGridMoveArgs e)
     {

--- a/Slider/Assets/Scripts/Sliders/SMove/SMove.cs
+++ b/Slider/Assets/Scripts/Sliders/SMove/SMove.cs
@@ -96,6 +96,11 @@ public class SMoveSwap : SMove
         moves.Add(new Vector4Int(x1, y1, x2, y2));
         moves.Add(new Vector4Int(x2, y2, x1, y1));
     }
+
+    public Vector4Int GetSwapAsVector()
+    {
+        return moves[0];
+    }
 }
 
 //L: Used primarily in the "Ocean" area for rotating tiles around

--- a/Slider/Assets/Scripts/Sliders/SMove/SMove.cs
+++ b/Slider/Assets/Scripts/Sliders/SMove/SMove.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+//L: A representation of a move made on the artifact, as well as the borders around the move that prevent the player from clipping.
 public class SMove
 {
     public List<Vector4Int> moves = new List<Vector4Int>(); // move tile at (x, y) to (z, w)
@@ -53,7 +54,7 @@ public class SMove
          * L: We want to toggle the sides as opposed to just adding them because if a border is hit twice, it means that it is in the path of the move and is actually not a border.
          * Ex: If you are moving from (0, 1) to (1,1). 
          * First process (0,1) after which The top, left, bottom, and right sides of (0,1) will be added to the list. The left side of (1,1) is added when (1,1) is pos2.
-         * Next while (1,1) is being processed, since the left side has already been added, it will be removed, while the top, right, and bottom borders are added.
+         * Next, while (1,1) is being processed, since the left side has already been added, it will be removed, while the top, right, and bottom borders are added.
          *  ___ ___                              _______                       
          * |   |   | - without toggling         |       | - with toggling
          * |___|___|                            |_______|
@@ -87,7 +88,7 @@ public class Vector4Int
 }
 
 
-
+//L: Swapping includes moving a tile to an empty spot!
 public class SMoveSwap : SMove
 {
     public SMoveSwap(int x1, int y1, int x2, int y2)
@@ -97,7 +98,7 @@ public class SMoveSwap : SMove
     }
 }
 
-
+//L: Used primarily in the "Ocean" area for rotating tiles around
 public class SMoveRotate : SMove
 {
     public SMoveRotate(List<Vector2Int> points)

--- a/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButton.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButton.cs
@@ -87,6 +87,11 @@ public class ArtifactTileButton : MonoBehaviour
         buttonAnimator.SetPushedDown(v);
     }
 
+    public void SetSelected(bool v)
+    {
+        buttonAnimator.SetSelected(v);
+    }
+
     public void SetForcedPushedDown(bool v)
     {
         buttonAnimator.SetForcedPushedDown(v);

--- a/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButtonAnimator.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/ArtifactTileButtonAnimator.cs
@@ -9,26 +9,13 @@ public class ArtifactTileButtonAnimator : MonoBehaviour
     public Image pushedDownFrame;
     public Image highlightedFrame;
 
+    //The button is pushed down, regardless of the method
     private bool isPushedDown;
+    //The button is selected by the user to be able to make a move.
+    private bool isSelected;
+    //The button is forced down because it is still being moved.
     private bool isForcedPushedDown;
     private bool isHighlighted;
-
-    //public void UpdatePushedDown()
-    //{
-    //    if (isPushedDown)
-    //    {
-    //        sliderImage.rectTransform.anchoredPosition = new Vector3(0, -1);
-    //        highlightedFrame.rectTransform.anchoredPosition = new Vector3(0, -1);
-    //        pushedDownFrame.gameObject.SetActive(true);
-    //    }
-    //    else
-    //    {
-    //        isPushedDown = false;
-    //        sliderImage.rectTransform.anchoredPosition = new Vector3(0, 0);
-    //        highlightedFrame.rectTransform.anchoredPosition = new Vector3(0, 0);
-    //        pushedDownFrame.gameObject.SetActive(false);
-    //    }
-    //}
 
     public void SetPushedDown(bool value)
     {
@@ -39,7 +26,7 @@ public class ArtifactTileButtonAnimator : MonoBehaviour
             highlightedFrame.rectTransform.anchoredPosition = new Vector3(0, -1);
             pushedDownFrame.gameObject.SetActive(true);
         }
-        else if (isPushedDown && !value && !isForcedPushedDown)
+        else if (isPushedDown && !value)
         {
             isPushedDown = false;
             sliderImage.rectTransform.anchoredPosition = new Vector3(0, 0);
@@ -48,10 +35,16 @@ public class ArtifactTileButtonAnimator : MonoBehaviour
         }
     }
 
+    public void SetSelected(bool value)
+    {
+        isSelected = value;
+        SetPushedDown(isSelected || isForcedPushedDown);
+    }
+
     public void SetForcedPushedDown(bool value)
     {
         isForcedPushedDown = value;
-        SetPushedDown(value);
+        SetPushedDown(isSelected || isForcedPushedDown);
     }
 
     public void SetHighlighted(bool value)

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -13,14 +13,16 @@ public class UIArtifact : MonoBehaviour
     //L: The available buttons the player has to move to from currentButton
     private List<ArtifactTileButton> moveOptionButtons = new List<ArtifactTileButton>();
     //queue is used for when the player makes multiple moves before a move has finished.
-    private Queue<ArtifactTileButton> queue;
+    private Queue<SMove> queue;
+    public int maxMovesBuffered = 2;
+    IEnumerator queueEmptyCoroutine;
 
     private static UIArtifact _instance;
     
     public void Awake()
     {
         _instance = this;
-        queue = new Queue<ArtifactTileButton>();
+        queue = new Queue<SMove>();
     }
 
     public static UIArtifact GetInstance()
@@ -92,7 +94,7 @@ public class UIArtifact : MonoBehaviour
             b.buttonAnimator.sliderImage.sprite = b.emptySprite;
             if(b == hovered) 
             {
-                Swap(dragged, hovered);
+                CheckAndSwap(dragged, hovered, true);
 
             }
 
@@ -100,7 +102,7 @@ public class UIArtifact : MonoBehaviour
     }
     public void OnDisable()
     {
-        queue = new Queue<ArtifactTileButton>();
+        queue = new Queue<SMove>();
         Debug.Log("Queue Cleared!");
     }
 
@@ -123,31 +125,46 @@ public class UIArtifact : MonoBehaviour
         // Check if on movement cooldown
         //if (SGrid.GetStile(button.islandId).isMoving)
 
+        //L: This is basically just a bunch of nested logic to determine how to update the UI based on what button the user pressed.
+
+        ArtifactTileButton oldCurrButton = currentButton;
         if (currentButton != null)
         {
             if (moveOptionButtons.Contains(button))
             {
+                //L: Player makes a valid move on the artifact
                 if (currentButton.isForcedDown)
                 {
                     //L: Player makes a move while the tile is still moving, so add the button to the queue.
-                    QueueAdd(currentButton, button);
+                    if ((queue.Count < maxMovesBuffered) && CheckAndSwap(currentButton, button, true))
+                    {
+                        QueueCheckAndAdd(new SMoveSwap(currentButton.x, currentButton.y, button.x, button.y));
+                    }
 
                     //Debug.Log(currentButton.gameObject.name + " added to the queue!");
                     //Debug.Log(button.gameObject.name + " added to the Queue");
                 } else
                 {
                     //L: Player makes a move immediately
-                    Swap(currentButton, button);
+                    CheckAndSwap(currentButton, button);
                 }
-            }
 
-            DeselectCurrentButton();
+                moveOptionButtons = GetMoveOptions(currentButton);
+                foreach (ArtifactTileButton b in buttons)
+                {
+                    b.SetHighlighted(moveOptionButtons.Contains(b));
+                }
+            } else 
+            {
+                DeselectCurrentButton();
+            } 
         }
-        else
+
+        if (currentButton == null)
         {
             //DeselectCurrentButton(); //L: I don't think this is necessary since currentButton is null and it will just do nothing
 
-            if (!button.isTileActive)
+            if (!button.isTileActive || oldCurrButton == button)
             {
                 //L: Player tried to click an empty tile
                 return;
@@ -171,11 +188,6 @@ public class UIArtifact : MonoBehaviour
                 }
             }
         }
-        //else
-        //{
-        //    // default deselect
-        //    DeselectCurrentButton();
-        //}
     }
 
     // replaces adjacentButtons
@@ -216,7 +228,17 @@ public class UIArtifact : MonoBehaviour
         return moveOptionButtons;
     }
 
-    private void Swap(ArtifactTileButton buttonCurrent, ArtifactTileButton buttonEmpty)
+    //L: Swaps the buttons on the UI, but not the actual grid.
+    private void SwapButtons(ArtifactTileButton buttonCurrent, ArtifactTileButton buttonEmpty)
+    {
+        int oldCurrX = buttonCurrent.x;
+        int oldCurrY = buttonCurrent.y;
+        buttonCurrent.SetPosition(buttonEmpty.x, buttonEmpty.y);
+        buttonEmpty.SetPosition(oldCurrX, oldCurrY);
+    }
+
+    //L: updateGrid - if this is false, it will just update the UI without actually moving the tiles.
+    private bool CheckAndSwap(ArtifactTileButton buttonCurrent, ArtifactTileButton buttonEmpty, bool queuedMove = false)
     {
         STile[,] currGrid = SGrid.current.GetGrid();
 
@@ -229,18 +251,21 @@ public class UIArtifact : MonoBehaviour
 
             SMove swap = new SMoveSwap(x, y, buttonEmpty.x, buttonEmpty.y);
             
-            
             if (SGrid.current.CanMove(swap))
             {
-                SGrid.current.Move(swap);
-                buttonCurrent.SetPosition(buttonEmpty.x, buttonEmpty.y);
-                buttonEmpty.SetPosition(x, y);
-                StartCoroutine(SetForcePushedDown(buttonCurrent));
-
+                //L: If the move is queued (queuedMove) then we need to wait until the move is dequed before doing it to the grid.
+                if (!queuedMove)
+                {
+                    SGrid.current.Move(swap);
+                    StartCoroutine(WaitForMoveThenEmptyQueue(buttonCurrent));
+                }
+                SwapButtons(buttonCurrent, buttonEmpty);
+                return true;
             }
             else
             {
                 Debug.Log("Couldn't perform move!");
+                return false;
             }
         }
         else 
@@ -249,61 +274,86 @@ public class UIArtifact : MonoBehaviour
             int dx = buttonEmpty.x - x;
             int dy = buttonEmpty.y - y;
 
-            //L: These aren't actually needed
-            //I'm just testing if getting the tile coords gives different results from the double for loop,
-            //and if it does, we can delete the loop entirely.
-            int oldLinkx = currGrid[x, y].x;    
-            int oldLinky = currGrid[x, y].y;
-            
-            int linkx = oldLinkx;
-            int linky = oldLinky;
-            for (int i=0; i<SGrid.current.width; i++) 
-            {
-                for (int j=0; j<SGrid.current.height; j++) 
-                {
-                    if (currGrid[x,y].linkTile == currGrid[i,j]) 
-                    {
-                        
-                        linkx = i;
-                        linky = j;
-                    }
-                }
-            }
-            if (oldLinkx != linkx || oldLinky != linky)
-            {
-                Debug.LogError("We need dumb for loop for links :(");
-            }
+            Vector2Int linkCoords = getLinkTileCoords(buttonCurrent);
+            int linkx = linkCoords.x;
+            int linky = linkCoords.y;
             
             SMove swap = new SMoveSwap(x, y, buttonEmpty.x, buttonEmpty.y);
             SMove swap2 = new SMoveSwap(linkx, linky, linkx+dx, linky+dy);
             Vector4Int movecoords = new Vector4Int(linkx, linky, linkx+dx, linky+dy);
             if (SGrid.current.CanMove(swap) && (OpenPath(movecoords, SGrid.current.GetGrid()) || currGrid[linkx+dx,linky+dy] == currGrid[x,y])) 
             {
-                ArtifactTileButton buttonCurrent2 = null;
-                ArtifactTileButton buttonEmpty2 = null;
+                if (!queuedMove)
+                {
+                    SGrid.current.Move(swap);
+                    SGrid.current.Move(swap2);
+                    StartCoroutine(WaitForMoveThenEmptyQueue(buttonCurrent));
+                }
 
+                //L: Swap the current button and the link button
+                SwapButtons(buttonCurrent, buttonEmpty);
+                SwapButtons(GetButton(linkx, linky), GetButton(linkx + dx, linky + dy));
 
-                SGrid.current.Move(swap);
-                SGrid.current.Move(swap2);
-
-                buttonCurrent.SetPosition(buttonEmpty.x, buttonEmpty.y);
-                StartCoroutine(SetForcePushedDown(buttonCurrent));
-                buttonEmpty.SetPosition(x, y);
-
-                buttonCurrent2 = GetButton(linkx, linky);
-                buttonEmpty2 = GetButton(linkx+dx, linky+dy);
-                StartCoroutine(SetForcePushedDown(buttonCurrent2));
-                buttonCurrent2.SetPosition(linkx+dx, linky+dy);
-                buttonEmpty2.SetPosition(linkx, linky);
-
-
+                return true;
             }
             else 
             {
                 // Debug.Log("illegal");
                 AudioManager.Play("Artifact Error");
+                return false;
             }
         }
+    }
+
+    private void UpdateGridAfterButtonSwap(int prevX, int prevY, int x, int y)
+    {
+        SMove swap = new SMoveSwap(prevX, prevY, x, y);
+        SGrid.current.Move(swap);
+
+        if (SGrid.current.GetGrid()[prevX, prevY].linkTile != null)
+        {
+            Vector2Int linkCoords = getLinkTileCoords(currentButton);
+            int linkx = linkCoords.x;
+            int linky = linkCoords.y;
+            int dx = currentButton.x - prevX;
+            int dy = currentButton.y - prevY;
+            SMove swap2 = new SMoveSwap(linkx, linky, linkx + dx, linky + dy);
+            SGrid.current.Move(swap2);
+        }
+    }
+
+    private Vector2Int getLinkTileCoords(ArtifactTileButton buttonCurrent)
+    {
+        STile[,] currGrid = SGrid.current.GetGrid();
+        int x = buttonCurrent.x;
+        int y = buttonCurrent.y;
+
+        //L: These aren't actually needed
+        //I'm just testing if getting the tile coords gives different results from the double for loop,
+        //and if it does, we can delete the loop entirely.
+        int oldLinkx = currGrid[x, y].linkTile.x;
+        int oldLinky = currGrid[x, y].linkTile.y;
+
+        int linkx = oldLinkx;
+        int linky = oldLinky;
+        for (int i = 0; i < SGrid.current.width; i++)
+        {
+            for (int j = 0; j < SGrid.current.height; j++)
+            {
+                if (currGrid[x, y].linkTile == currGrid[i, j])
+                {
+
+                    linkx = i;
+                    linky = j;
+                }
+            }
+        }
+        if (oldLinkx != linkx || oldLinky != linky)
+        {
+            Debug.LogError("We need dumb for loop for links :(");
+        }
+
+        return new Vector2Int(x, y);
     }
 
     //Checks if the move can happen on the grid.
@@ -331,14 +381,45 @@ public class UIArtifact : MonoBehaviour
         }
         return true;
     }
-    private IEnumerator SetForcePushedDown(ArtifactTileButton button)
+
+    public void QueueCheckAndAdd(SMove move)
+    {
+        if (queue.Count < maxMovesBuffered)
+        {
+            queue.Enqueue(move);
+        } else
+        {
+            Debug.LogWarning("Didn't add to the UIArtifact queue because it was full");
+        }
+
+    }
+
+    public bool QueueCheckAndRemove()
+    {
+        if (queue.Count != 0)
+        {
+            SMove move = queue.Dequeue();
+            //Debug.Log("Swapping " + currentButton.gameObject.name + " with " + emptyButton.gameObject.name);
+
+            //L: Update the grid since the Artifact UI should have already updated.
+            Vector4Int swap = ((SMoveSwap) move).GetSwapAsVector();
+            UpdateGridAfterButtonSwap(swap.x, swap.y, swap.z, swap.w);
+            return true;
+        }
+
+        return false;
+    }
+
+    private IEnumerator WaitForMoveThenEmptyQueue(ArtifactTileButton button)
     {
         button.SetForcedPushedDown(true);
 
-        yield return new WaitForSeconds(1);
-        
+        do
+        {
+            yield return new WaitForSeconds(1);
+        } while (QueueCheckAndRemove());
+
         button.SetForcedPushedDown(false);
-        CheckQueue();
     }
 
     //public static void UpdatePushedDowns()
@@ -348,7 +429,7 @@ public class UIArtifact : MonoBehaviour
     //        b.UpdatePushedDown();
     //    }
     //}
-    
+
     //L: Mark the button on the Artifact UI at islandID if it is in the right spot. (also changes the sprite)
     public static void SetButtonComplete(int islandId, bool value)
     {
@@ -407,23 +488,6 @@ public class UIArtifact : MonoBehaviour
             {
                 b.Flicker();
             }
-        }
-    }
-
-    public void QueueAdd(ArtifactTileButton currentButton, ArtifactTileButton buttonEmpty)
-    {
-        queue.Enqueue(currentButton);
-        queue.Enqueue(buttonEmpty);
-    }
-
-    public void CheckQueue()
-    {
-        if (queue.Count != 0)
-        {
-            ArtifactTileButton currentButton = queue.Dequeue();
-            ArtifactTileButton emptyButton = queue.Dequeue();
-            //Debug.Log("Swapping " + currentButton.gameObject.name + " with " + emptyButton.gameObject.name);
-            Swap(currentButton, emptyButton);
         }
     }
 }

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -94,8 +94,7 @@ public class UIArtifact : MonoBehaviour
             b.buttonAnimator.sliderImage.sprite = b.emptySprite;
             if(b == hovered) 
             {
-                CheckAndSwap(dragged, hovered, true);
-
+                CheckAndSwap(dragged, hovered, false);
             }
 
         }
@@ -103,7 +102,7 @@ public class UIArtifact : MonoBehaviour
     public void OnDisable()
     {
         queue = new Queue<SMove>();
-        Debug.Log("Queue Cleared!");
+        //Debug.Log("Queue Cleared!");
     }
 
     public void DeselectCurrentButton()

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -321,7 +321,7 @@ public class UIArtifact : MonoBehaviour
         }
     }
 
-    private Vector2Int getLinkTileCoords(ArtifactTileButton buttonCurrent)
+    private Vector2Int GetLinkTileCoords(ArtifactTileButton buttonCurrent)
     {
         STile[,] currGrid = SGrid.current.GetGrid();
         int x = buttonCurrent.x;

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -8,8 +8,11 @@ public class UIArtifact : MonoBehaviour
 {
     // public Vector3 tempPosition = new Vector3(0,0,0);
     public ArtifactTileButton[] buttons;
+    //L: The button the user has clicked on
     private ArtifactTileButton currentButton;
-    private List<ArtifactTileButton> adjacentButtons = new List<ArtifactTileButton>();
+    //L: The available buttons the player has to move to from currentButton
+    private List<ArtifactTileButton> moveOptionButtons = new List<ArtifactTileButton>();
+    //queue is used for when the player makes multiple moves before a move has finished.
     private Queue<ArtifactTileButton> queue;
 
     private static UIArtifact _instance;
@@ -25,7 +28,7 @@ public class UIArtifact : MonoBehaviour
         return _instance;
     }
 
-
+    //L: Handles when the user attempts to drag and drop a button
     public void ButtonDragged(BaseEventData eventData) {
         // Debug.Log("dragging");
         PointerEventData data = (PointerEventData) eventData;
@@ -48,7 +51,7 @@ public class UIArtifact : MonoBehaviour
         }
 
         
-        foreach (ArtifactTileButton b in GetAdjacent(dragged)) {
+        foreach (ArtifactTileButton b in GetMoveOptions(dragged)) {
             if(b == hovered) 
             {
                 b.buttonAnimator.sliderImage.sprite = b.hoverSprite;
@@ -85,7 +88,7 @@ public class UIArtifact : MonoBehaviour
         hovered.buttonAnimator.sliderImage.sprite = hovered.emptySprite;
         //Debug.Log("dragged" + dragged.islandId + "hovered" + hovered.islandId);
 
-        foreach (ArtifactTileButton b in GetAdjacent(dragged)) {
+        foreach (ArtifactTileButton b in GetMoveOptions(dragged)) {
             b.buttonAnimator.sliderImage.sprite = b.emptySprite;
             if(b == hovered) 
             {
@@ -107,55 +110,62 @@ public class UIArtifact : MonoBehaviour
             return;
 
         currentButton.SetPushedDown(false);
-        foreach (ArtifactTileButton b in adjacentButtons)
+        foreach (ArtifactTileButton b in moveOptionButtons)
         {
             b.SetHighlighted(false);
         }
         currentButton = null;
-        adjacentButtons.Clear();
+        moveOptionButtons.Clear();
     }
     
     public virtual void SelectButton(ArtifactTileButton button)
     {
         // Check if on movement cooldown
         //if (SGrid.GetStile(button.islandId).isMoving)
-        if (currentButton != null && currentButton.isForcedDown && adjacentButtons.Contains(button))
-        {
-            //Debug.Log(currentButton.gameObject.name + " added to the queue!");
-            //Debug.Log(button.gameObject.name + " added to the Queue");
-            QueueAdd(currentButton, button);
-            DeselectCurrentButton();
-        }
 
-        else if (currentButton == button)
+        if (currentButton != null)
         {
-            DeselectCurrentButton();
-        }
-        else if (adjacentButtons.Contains(button)) // compare by id?
-        {
-            Swap(currentButton, button);
+            if (moveOptionButtons.Contains(button))
+            {
+                if (currentButton.isForcedDown)
+                {
+                    //L: Player makes a move while the tile is still moving, so add the button to the queue.
+                    QueueAdd(currentButton, button);
+
+                    //Debug.Log(currentButton.gameObject.name + " added to the queue!");
+                    //Debug.Log(button.gameObject.name + " added to the Queue");
+                } else
+                {
+                    //L: Player makes a move immediately
+                    Swap(currentButton, button);
+                }
+            }
+
             DeselectCurrentButton();
         }
         else
         {
-            DeselectCurrentButton();
+            //DeselectCurrentButton(); //L: I don't think this is necessary since currentButton is null and it will just do nothing
 
             if (!button.isTileActive)
             {
+                //L: Player tried to click an empty tile
                 return;
             }
 
-            adjacentButtons = GetAdjacent(button);
-            if (adjacentButtons.Count == 0)
+            moveOptionButtons = GetMoveOptions(button);
+            if (moveOptionButtons.Count == 0)
             {
+                //L: Player tried to click a locked tile (or tile that otherwise had no move options)
                 return;
             }
             else
             {
+                //L: Player clicked a tile with movement options
                 //Debug.Log("Selected button " + button.islandId);
                 currentButton = button;
                 button.SetPushedDown(true);
-                foreach (ArtifactTileButton b in adjacentButtons)
+                foreach (ArtifactTileButton b in moveOptionButtons)
                 {
                     b.SetHighlighted(true);
                 }
@@ -169,9 +179,9 @@ public class UIArtifact : MonoBehaviour
     }
 
     // replaces adjacentButtons
-    protected List<ArtifactTileButton> GetAdjacent(ArtifactTileButton button)
+    protected List<ArtifactTileButton> GetMoveOptions(ArtifactTileButton button)
     {
-        adjacentButtons.Clear();
+        moveOptionButtons.Clear();
 
         //Vector2 buttPos = new Vector2(button.x, button.y);
         // foreach (ArtifactTileButton b in buttons)
@@ -192,34 +202,27 @@ public class UIArtifact : MonoBehaviour
 
         foreach (Vector2Int dir in dirs)
         {
+            ArtifactTileButton b = GetButton(button.x + dir.x, button.y + dir.y);
             int i = 1;
-            bool didAdd = true;
-            ArtifactTileButton b;
-            while (didAdd && i < 99)
+            while (b != null && !b.isTileActive)
             {
-                didAdd = false;
-
+                moveOptionButtons.Add(b);
                 b = GetButton(button.x + dir.x * i, button.y + dir.y * i);
-                
-                if (b != null && !b.isTileActive) {
-                    adjacentButtons.Add(b);
-                    didAdd = true;
-                }
-                    
-                i += 1;
+
+                i++;
             }
         }
 
-        return adjacentButtons;
+        return moveOptionButtons;
     }
 
     private void Swap(ArtifactTileButton buttonCurrent, ArtifactTileButton buttonEmpty)
     {
-        STile[,] arr = SGrid.current.GetGrid();
+        STile[,] currGrid = SGrid.current.GetGrid();
 
         int x = buttonCurrent.x;
         int y = buttonCurrent.y;
-        if (arr[x, y].linkTile == null) 
+        if (currGrid[x, y].linkTile == null) 
         {
             //Direction dir = DirectionUtil.V2D(new Vector2(buttonEmpty.x, buttonEmpty.y) - new Vector2(x, y));
             //EightPuzzle.MoveSlider(x, y, dir);
@@ -241,15 +244,23 @@ public class UIArtifact : MonoBehaviour
         }
         else 
         {
+            //L: Below is to handle the case for if you have linked tiles.
             int dx = buttonEmpty.x - x;
             int dy = buttonEmpty.y - y;
-            int linkx = -1;
-            int linky = -1;
+
+            //L: These aren't actually needed
+            //I'm just testing if getting the tile coords gives different results from the double for loop,
+            //and if it does, we can delete the loop entirely.
+            int oldLinkx = currGrid[x, y].x;    
+            int oldLinky = currGrid[x, y].y;
+            
+            int linkx = oldLinkx;
+            int linky = oldLinky;
             for (int i=0; i<SGrid.current.width; i++) 
             {
                 for (int j=0; j<SGrid.current.height; j++) 
                 {
-                    if (arr[x,y].linkTile == arr[i,j]) 
+                    if (currGrid[x,y].linkTile == currGrid[i,j]) 
                     {
                         
                         linkx = i;
@@ -257,21 +268,28 @@ public class UIArtifact : MonoBehaviour
                     }
                 }
             }
+            if (oldLinkx != linkx || oldLinky != linky)
+            {
+                Debug.LogError("We need dumb for loop for links :(");
+            }
+            
             SMove swap = new SMoveSwap(x, y, buttonEmpty.x, buttonEmpty.y);
             SMove swap2 = new SMoveSwap(linkx, linky, linkx+dx, linky+dy);
             Vector4Int movecoords = new Vector4Int(linkx, linky, linkx+dx, linky+dy);
-            if (SGrid.current.CanMove(swap) && (OpenPath(movecoords, SGrid.current.GetGrid()) || arr[linkx+dx,linky+dy] == arr[x,y])) 
+            if (SGrid.current.CanMove(swap) && (OpenPath(movecoords, SGrid.current.GetGrid()) || currGrid[linkx+dx,linky+dy] == currGrid[x,y])) 
             {
                 ArtifactTileButton buttonCurrent2 = null;
                 ArtifactTileButton buttonEmpty2 = null;
 
-                buttonCurrent2 = GetButton(linkx, linky);
+
                 SGrid.current.Move(swap);
                 SGrid.current.Move(swap2);
+
                 buttonCurrent.SetPosition(buttonEmpty.x, buttonEmpty.y);
                 StartCoroutine(SetForcePushedDown(buttonCurrent));
                 buttonEmpty.SetPosition(x, y);
-               
+
+                buttonCurrent2 = GetButton(linkx, linky);
                 buttonEmpty2 = GetButton(linkx+dx, linky+dy);
                 StartCoroutine(SetForcePushedDown(buttonCurrent2));
                 buttonCurrent2.SetPosition(linkx+dx, linky+dy);
@@ -285,10 +303,9 @@ public class UIArtifact : MonoBehaviour
                 AudioManager.Play("Artifact Error");
             }
         }
-
-
     }
 
+    //Checks if the move can happen on the grid.
     private bool OpenPath(Vector4Int move, STile[,] grid) {
         List<Vector2Int> checkedCoords = new List<Vector2Int>(); 
         int dx = move.z - move.x;
@@ -331,6 +348,7 @@ public class UIArtifact : MonoBehaviour
     //    }
     //}
     
+    //L: Mark the button on the Artifact UI at islandID if it is in the right spot. (also changes the sprite)
     public static void SetButtonComplete(int islandId, bool value)
     {
         foreach (ArtifactTileButton b in _instance.buttons)

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -273,7 +273,7 @@ public class UIArtifact : MonoBehaviour
             int dx = buttonEmpty.x - x;
             int dy = buttonEmpty.y - y;
 
-            Vector2Int linkCoords = getLinkTileCoords(buttonCurrent);
+            Vector2Int linkCoords = GetLinkTileCoords(buttonCurrent);
             int linkx = linkCoords.x;
             int linky = linkCoords.y;
             
@@ -311,7 +311,7 @@ public class UIArtifact : MonoBehaviour
 
         if (SGrid.current.GetGrid()[prevX, prevY].linkTile != null)
         {
-            Vector2Int linkCoords = getLinkTileCoords(currentButton);
+            Vector2Int linkCoords = GetLinkTileCoords(currentButton);
             int linkx = linkCoords.x;
             int linky = linkCoords.y;
             int dx = currentButton.x - prevX;

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -109,7 +109,7 @@ public class UIArtifact : MonoBehaviour
         if (currentButton == null)
             return;
 
-        currentButton.SetPushedDown(false);
+        currentButton.SetSelected(false);
         foreach (ArtifactTileButton b in moveOptionButtons)
         {
             b.SetHighlighted(false);
@@ -164,7 +164,7 @@ public class UIArtifact : MonoBehaviour
                 //L: Player clicked a tile with movement options
                 //Debug.Log("Selected button " + button.islandId);
                 currentButton = button;
-                button.SetPushedDown(true);
+                button.SetSelected(true);
                 foreach (ArtifactTileButton b in moveOptionButtons)
                 {
                     b.SetHighlighted(true);
@@ -234,8 +234,9 @@ public class UIArtifact : MonoBehaviour
             {
                 SGrid.current.Move(swap);
                 buttonCurrent.SetPosition(buttonEmpty.x, buttonEmpty.y);
-                StartCoroutine(SetForcePushedDown(buttonCurrent));
                 buttonEmpty.SetPosition(x, y);
+                StartCoroutine(SetForcePushedDown(buttonCurrent));
+
             }
             else
             {

--- a/Slider/Assets/Scripts/UI/UIManager.cs
+++ b/Slider/Assets/Scripts/UI/UIManager.cs
@@ -113,6 +113,8 @@ public class UIManager : MonoBehaviour
             artifactAnimator.SetBool("isVisible", false);
             StartCoroutine(CloseArtPanel());
         }
+
+        uiArtifact.DeselectCurrentButton();
     }
 
     private IEnumerator CloseArtPanel()

--- a/Slider/Packages/manifest.json
+++ b/Slider/Packages/manifest.json
@@ -12,6 +12,7 @@
     "com.unity.ide.visualstudio": "2.0.12",
     "com.unity.ide.vscode": "1.2.4",
     "com.unity.inputsystem": "1.2.0",
+    "com.unity.recorder": "2.5.7",
     "com.unity.render-pipelines.universal": "10.8.1",
     "com.unity.test-framework": "1.1.29",
     "com.unity.textmeshpro": "3.0.6",

--- a/Slider/Packages/packages-lock.json
+++ b/Slider/Packages/packages-lock.json
@@ -149,6 +149,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.recorder": {
+      "version": "2.5.7",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.timeline": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.render-pipelines.core": {
       "version": "10.8.1",
       "depth": 1,


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Queue can now buffer up to 2 moves in advance (variable). 
- The buttons now move instantaneously, so the move options are always up to date.
- You don't have to reclick a button to make another move
- Drag and Drop might still be broken idk.
- Changed the Swap function by taking out certain parts of it and also added a flag that causes it to only update the artifact and not the grid.

## Related Task
<!--- What is the related trello task for this PR -->
Slider animation queue
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did a run through of the first area to make sure it didn't break.

## Screenshots (if appropriate):
gif