### PR TITLE
Make PlayerAction No Longer Trigger Artifact Buttons, Fix Buy Menu Issue

### DIFF
--- a/Slider/Assets/EventSystemManager.cs
+++ b/Slider/Assets/EventSystemManager.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// This is cancer. I hate Unity. The only decent way to deselect a button is to have *this* script attached to the EventSystem
+/// and call a method to clear the selected UI element.....
+/// </summary>
+public class EventSystemManager : MonoBehaviour
+{
+    private static EventSystemManager _instance;
+
+    private UnityEngine.EventSystems.EventSystem eventSystem;
+
+    /// <summary>
+    /// Call this to deslect the currently select button. No, there isn't a better approach to this. Yes, that drives me insane.
+    /// </summary>
+    public static void ClearSelectable()
+    {
+        _instance.eventSystem.SetSelectedGameObject(null);
+        Debug.Log(_instance.eventSystem.currentSelectedGameObject);
+    }
+
+    private void Awake()
+    {
+        _instance = this;
+        _instance.eventSystem = GetComponent<UnityEngine.EventSystems.EventSystem>();
+    }
+}

--- a/Slider/Assets/EventSystemManager.cs.meta
+++ b/Slider/Assets/EventSystemManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df5b7d3ceed6b224bb1530c694d9042b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Slider/Assets/Scripts/UI/Helper/UIClick.cs
+++ b/Slider/Assets/Scripts/UI/Helper/UIClick.cs
@@ -4,11 +4,22 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
+/// <summary>
+/// Contains functionality for playing sound OnClick and selecting the button OnPointerEnter or OnEnable.
+/// </summary>
 public class UIClick : MonoBehaviour, IPointerEnterHandler
 {
     Button button;
+
     [Tooltip("Set this true to make this the default button selected when the menu opens")]
     [SerializeField] private bool isSelectedOnMenuOpen;
+    [Tooltip("Set this true to make this button selected when the pointer moves over it. " +
+        "This means that the button will be triggered if PlayerAction is pressed while the cursor it")]
+    [SerializeField] private bool selectOnPointerEnter;
+
+    [Tooltip("Set this true to make the button not stay selected after being clicked. Useful if you" +
+        "don't want PlayerAction to trigger this button.")]
+    [SerializeField] private bool deselectOnClick;
 
     private void OnEnable()
     {
@@ -27,7 +38,6 @@ public class UIClick : MonoBehaviour, IPointerEnterHandler
     /// <returns></returns>
     private IEnumerator IOnEnable()
     {
-
         // Apparently we have this script on some things without a button component, so let's avoid
         // scary NREs in the console
         if (button != null)
@@ -47,16 +57,23 @@ public class UIClick : MonoBehaviour, IPointerEnterHandler
 
     public void Click()
     {
+        if (deselectOnClick)
+        {
+            EventSystemManager.ClearSelectable();
+        }
         AudioManager.Play("UI Click");
     }
 
     // Player can use the mouse or movement keys to select buttons
     public void OnPointerEnter(PointerEventData eventData)
     {
-        if (button == null)
+        if (selectOnPointerEnter)
         {
-            button = GetComponent<Button>();
+            if (button == null)
+            {
+                button = GetComponent<Button>();
+            }
+            button.Select();
         }
-        button.Select();
     }
 }

--- a/Slider/Assets/TavernkeeperBuyMenuManager.cs
+++ b/Slider/Assets/TavernkeeperBuyMenuManager.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// We need this to handle selecting a new button after a slider is purchased from the buy menu in the tavernkeeper UI.
+/// </summary>
+public class TavernkeeperBuyMenuManager : MonoBehaviour
+{
+    [Tooltip("Place all of the buy buttons here. They should be ordered from top to " +
+        "bottom so that we select the uppermost one when buying a slider.")]
+    [SerializeField] private Button[] buttons;
+
+    /// <summary>
+    /// Selects the first buy button in the list of buttons stored in this component.
+    /// </summary>
+    public void SelectUppermostBuyButton()
+    {
+        foreach (Button button in buttons)
+        {
+            if (button.gameObject.activeInHierarchy)
+            {
+                button.Select();
+                break;
+            }
+        }
+    }
+
+    private void OnEnable()
+    {
+        SelectUppermostBuyButton();
+    }
+}

--- a/Slider/Assets/TavernkeeperBuyMenuManager.cs.meta
+++ b/Slider/Assets/TavernkeeperBuyMenuManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a42f1aee26f69934fbf9cdbe5785e32c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Description
- PlayerAction no longer selects buttons in the artifact menu (specifically in the Ocean area.) 
- Buying a slider in the buy menu of the Tavernkeeper UI now selects the uppermost buy button. The same is true when re-entering the menu after buying a slider.

## Related Task
[Make arrow keys/WASD work in tavernkeeper ui](https://trello.com/c/9oOtL6Ao)

## How Has This Been Tested?
It works, please trust me.

## Screenshots (if appropriate):
