### PR TITLE
Update Singleton, Suppress Some Warnings

### DIFF
--- a/Slider/Assets/Scripts/Audio/AudioManager.cs
+++ b/Slider/Assets/Scripts/Audio/AudioManager.cs
@@ -30,13 +30,11 @@ public class AudioManager : Singleton<AudioManager>
 
     void Awake()
     {
-        if (_instance != null)
+        if (InitializeSingleton(destroyIfInstanceIsAlreadySet:gameObject))
         {
-            Destroy(gameObject);
             return;
         }
         DontDestroyOnLoad(gameObject);
-        InitializeSingleton();
 
         _sounds = sounds;
         _music = music;

--- a/Slider/Assets/Scripts/Audio/AudioManager.cs
+++ b/Slider/Assets/Scripts/Audio/AudioManager.cs
@@ -30,7 +30,7 @@ public class AudioManager : Singleton<AudioManager>
 
     void Awake()
     {
-        if (InitializeSingleton(destroyIfInstanceIsAlreadySet:gameObject))
+        if (InitializeSingleton(ifInstanceAlreadySetThenDestroy:gameObject))
         {
             return;
         }

--- a/Slider/Assets/Scripts/Discord/DiscordController.cs
+++ b/Slider/Assets/Scripts/Discord/DiscordController.cs
@@ -8,11 +8,16 @@ using UnityEngine.SceneManagement;
 /// Handles Discord Rich Presence. Should probably be attached to GameManager or
 /// some other object which exists at game start and persists through scenes.
 /// </summary>
-public class DiscordController : MonoBehaviour
+public class DiscordController : Singleton<DiscordController>
 {
     private const long CLIENT_ID = 953335446056882186;
     private Discord.Discord discord; // This looks hilarious but it's how the SDK works
     private long secondsSinceEpoch; // Used for tracking time elapsed
+
+    private void Awake()
+    {
+        InitializeSingleton(ifInstanceAlreadySetThenDestroy:this);
+    }
 
     void Start()
     {
@@ -20,7 +25,7 @@ public class DiscordController : MonoBehaviour
         {
             // Going with not requiring Discord seems like the safer option to me.
             // Not entirely sure of the consequences here to be honest
-            discord = new Discord.Discord(CLIENT_ID, (ulong)Discord.CreateFlags.NoRequireDiscord);
+            discord = new Discord.Discord(CLIENT_ID, (ulong) Discord.CreateFlags.NoRequireDiscord);
             //InvokeRepeating("UpdateActivity", 0, 5);
 
             // We need our epoch time for tracking time elapsed

--- a/Slider/Assets/Scripts/Discord/DiscordController.cs
+++ b/Slider/Assets/Scripts/Discord/DiscordController.cs
@@ -33,7 +33,7 @@ public class DiscordController : MonoBehaviour
 
             UpdateActivity();
 
-            Debug.Log("Starting Rich Presence");
+            //Debug.Log("Starting Rich Presence");
         }
     }
 

--- a/Slider/Assets/Scripts/Map/Mountain/Meltable.cs
+++ b/Slider/Assets/Scripts/Map/Mountain/Meltable.cs
@@ -9,7 +9,10 @@ public class Meltable : MonoBehaviour
     public Sprite frozenSprite; //C: switch to animation later maybe? but that doesn't sound fun
     public Sprite meltedSprite;
     public SpriteRenderer spriteRenderer;
+
+#pragma warning disable
     public Collider2D collider;
+#pragma warning restore
 
     public bool isFrozen = true;
 

--- a/Slider/Assets/Scripts/Map/Puzzles/ChadRace.cs
+++ b/Slider/Assets/Scripts/Map/Puzzles/ChadRace.cs
@@ -34,8 +34,10 @@ public class ChadRace : MonoBehaviour
     private bool inStart;
     private float startTime;
 
+#pragma warning disable
     // Keeps track if this is the first time the play has tried the race with the current tile positions
     private bool firstTime;
+#pragma warning restore
 
     private float jungleChadEnd;
 

--- a/Slider/Assets/Scripts/Misc/Singleton.cs
+++ b/Slider/Assets/Scripts/Misc/Singleton.cs
@@ -61,15 +61,27 @@ public abstract class Singleton<T> : MonoBehaviour
     /// This should be called in Awake inside of all singleton components. This sets up _instance to be the component instance,
     /// enforces singleton-ness, and logs an error if one or more duplicates of the component are detected.
     /// </summary>
-    /// /// <param name="destroyIfInstanceIsAlreadySet">If _instance is already set, the passed in GameObject will be destroyed.</param>
+    /// /// <param name="ifInstanceAlreadySetThenDestroy">If _instance is already set, the passed in GameObject or MonoBehaviour will be destroyed.</param>
     /// <param name="allowInactiveDuplicates">If this is true, inactive duplicates of this singleton component will not be deleted, 
     /// nor will errors be logged because of them</param>
     /// <returns>True if _instance was successfully updated, false otherwise</returns>
-    protected virtual bool InitializeSingleton(GameObject destroyIfInstanceIsAlreadySet, bool allowInactiveDuplicates = false)
+    protected virtual bool InitializeSingleton(object ifInstanceAlreadySetThenDestroy, bool allowInactiveDuplicates = false)
     {
-        if (destroyIfInstanceIsAlreadySet != null && _instance != null)
+        if (ifInstanceAlreadySetThenDestroy != null && _instance != null)
         {
-            Destroy(destroyIfInstanceIsAlreadySet);
+            if (ifInstanceAlreadySetThenDestroy is MonoBehaviour behaviour)
+            {
+                Destroy(behaviour);
+            }
+            else if (ifInstanceAlreadySetThenDestroy is GameObject gObject)
+            {
+                Destroy(gObject);
+            }
+            else
+            {
+                Debug.Log("The parameter ifInstanceAlreadySetThenDestroy was neither a MonoBehaviour nor a GameObject, which is not allowed.");
+                return false;
+            }
             return true;
         } else
         {

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/DesertGrid.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/DesertGrid.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+
 public class DesertGrid : SGrid
 {
     public static DesertGrid instance;
@@ -21,7 +22,10 @@ public class DesertGrid : SGrid
 
     public DiceGizmo dice1;
     public DiceGizmo dice2;
+
+#pragma warning disable
     private bool diceWon = false;
+#pragma warning restore
 
     private bool VIPHelped = false;
 

--- a/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/Mountain/MountainUITrackerManager.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/Mountain/MountainUITrackerManager.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 
 public class MountainUITrackerManager : UITrackerManager
 {
+#pragma warning disable
     public static MountainUITrackerManager _instance;
+#pragma warning restore
 
     private Vector2 xOffset = new Vector2(35f/50f, -16f/50f);
     private Vector2 yOffset = new Vector2(35f/50f, 16f/50f);

--- a/Slider/Assets/Scripts/UI/UINavigationManager.cs
+++ b/Slider/Assets/Scripts/UI/UINavigationManager.cs
@@ -1,8 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.UI;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
@@ -18,9 +16,6 @@ using UnityEngine.UI;
 /// <remarks>Author: Travis</remarks>
 public class UINavigationManager : Singleton<UINavigationManager>
 {
-    // ** This class cannot be converted to Singleton without tons of issues :( **
-    //private static UINavigationManager _instance;
-
     private UnityEngine.EventSystems.EventSystem eventSystem;
 
     [Tooltip("Match each UI panel GameObject with all the navigatable buttons inside of it.")]


### PR DESCRIPTION
## Description
Singleton now supports "if instance is already set then destroy the one trying to take over right now"

This also suppresses some warnings that were driving me slowly insane.

## Related Task
N/A

## How Has This Been Tested?
Moved between Main Menu, Cutscene, and Village and confirmed that audio still worked properly