### PR TITLE
fixed tile dragging and auto move interaction bug

### DIFF
--- a/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/OceanArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/OceanArtifact.cs
@@ -39,7 +39,7 @@ public class OceanArtifact : UIArtifact
         // do nothing
     }
     
-    public override void SelectButton(ArtifactTileButton button) 
+    public override void SelectButton(ArtifactTileButton button, bool isDragged = false) 
     {
         // do nothing
     }

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -129,7 +129,7 @@ public class UIArtifact : MonoBehaviour
         }
         else
         {
-            SelectButton(dragged);
+            SelectButton(dragged, true);
         }
 
         ArtifactTileButton hovered = null;
@@ -206,14 +206,14 @@ public class UIArtifact : MonoBehaviour
             // b.buttonAnimator.sliderImage.sprite = b.emptySprite;
             if(b == hovered && !swapped) 
             {
-                SelectButton(hovered);
+                SelectButton(hovered, true);
                 // CheckAndSwap(dragged, hovered);
                 // SGridAnimator.OnSTileMoveEnd += dragged.AfterStileMoveDragged;
                 swapped = true;
             }
         }
         if (!swapped) {
-            SelectButton(dragged);
+            SelectButton(dragged, true);
         }
         else
         {
@@ -239,7 +239,7 @@ public class UIArtifact : MonoBehaviour
         //OnButtonInteract?.Invoke(this, null);
     }
     
-    public virtual void SelectButton(ArtifactTileButton button)
+    public virtual void SelectButton(ArtifactTileButton button, bool isDragged = false)
     {
         // Check if on movement cooldown
         //if (SGrid.GetStile(button.islandId).isMoving)
@@ -278,7 +278,7 @@ public class UIArtifact : MonoBehaviour
                 return;
             }
             //tile can only go one location so just auto move 
-            else if(moveOptionButtons.Count == 1 && SettingsManager.AutoMove)
+            else if(moveOptionButtons.Count == 1 && SettingsManager.AutoMove && !isDragged)
             {
                 currentButton = button;
                 currentButton.SetSelected(true);


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->
which solved the weird bug which occured when automove was active and the player tried dragging the tile instead of clicking
## Description
<!--- Describe your changes in detail -->
I added an additional bool argument to SelectButton  which allows it to know when it was called inside the 2 dragging methods and disables automove if so.
## Related Task
<!--- What is the related trello task for this PR -->
one of the bug ones ig
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
enabled automove and tried dragging and nothing weird happend (streamed it to daniel)
## Screenshots (if appropriate):
