### PR TITLE
improved fast moving and drag and drop behavior

### DIFF
--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -22,6 +22,8 @@ public class UIArtifact : Singleton<UIArtifact>
     public static System.EventHandler<System.EventArgs> OnButtonInteract;
     public static System.EventHandler<System.EventArgs> MoveMadeOnArtifact;
     
+    private int moveCounter;
+    
     protected void Awake()
     {
         if (!didInit)
@@ -275,12 +277,71 @@ public class UIArtifact : Singleton<UIArtifact>
         ResetButtonsToEmptyIfInactive(moveOptions);
 
         ArtifactTileButton hovered = GetButtonHovered(data);
-        if (hovered == null)
+        if(dragged == hovered && SettingsManager.AutoMove)
         {
-            return; //player didn't release mouse on a button, don't do anything.
+            SelectButton(dragged);
+            return;
+        }
+        //player didnt release their mouse on a tile so we assume they dont actually want to move the tile
+        if(hovered == null)
+        {
+            DeselectSelectedButton();
+            return; 
+        }
+        DoButtonDrag(dragged, hovered, moveOptions);
+    }
+    #endregion
+
+    #region Drag and Drop Private
+
+    private ArtifactTileButton GetButtonHovered(PointerEventData data)
+    {
+        ArtifactTileButton hovered = null;
+        if (data.pointerEnter != null && data.pointerEnter.name == "Image")
+        {
+            hovered = data.pointerEnter.transform.parent.gameObject.GetComponent<ArtifactTileButton>();
+        }
+        return hovered;
+    }
+
+    private void SetButtonVisualsDuringMouseDrag(ArtifactTileButton dragged, ArtifactTileButton hovered)
+    {
+        foreach (ArtifactTileButton b in GetMoveOptions(dragged))
+        {
+            if (b == hovered)
+            {
+                b.SetHighlighted(false);
+                b.SetSpriteToHover();
+            }
+            else
+            {
+                b.SetHighlighted(true);
+                b.SetSpriteToIslandOrEmpty();
+            }
+        }
+    }
+
+    private void DoButtonDrag(ArtifactTileButton dragged, ArtifactTileButton hovered, List<ArtifactTileButton> moveOptions)
+    {
+        //Debug.Log($"dragged: {dragged.islandId} hovered: {hovered.islandId}");
+        if (!hovered.TileIsActive)
+        {
+            hovered.SetSpriteToEmpty();
         }
 
-        DoButtonDrag(dragged, hovered, moveOptions);
+        foreach (ArtifactTileButton b in moveOptions)
+        {
+            b.SetHighlighted(false);
+            if (b == hovered)
+            {
+                SelectButton(hovered, true);
+                DeselectSelectedButton();
+                return;
+            }
+        }
+        SelectButton(dragged, true);
+
+        OnButtonInteract?.Invoke(this, null);
     }
     #endregion
 
@@ -439,7 +500,10 @@ public class UIArtifact : Singleton<UIArtifact>
             SMove move = moveQueue.Dequeue();
             if (CheckMoveHasAnActiveTile(move)) //L: If we don't do this, we risk adding an active move that never dequeues, overflowing the queue, and BREAKING THE ENTIRE GAME.
             {
-                move.duration *= 1f - moveQueue.Count / 10f;   //Queuing more moves will make it go faster.
+                //PJ: If only one move is in the queue then moveCounter gets reset to 0 cuz of the recursive call
+                //PJ: but generally we want queing alot of moves to result in increasingly faster execution of said moves
+                move.duration = Mathf.Max(1f - (moveCounter) / 10f, 0.5f);   
+                moveCounter += 1;
                 activeMoves.Add(move);
                 SGrid.Current.Move(move);
             }
@@ -448,6 +512,10 @@ public class UIArtifact : Singleton<UIArtifact>
                 Debug.LogError("The last dequeued move did not happen because it only contained empty tiles. THIS IS PROBABLY BECAUSE THE UI IS OUT OF SYNC WITH THE GRID.");
             }
             ProcessQueue();
+        }
+        else
+        {
+            moveCounter = 0;
         }
     }
 
@@ -618,57 +686,5 @@ public class UIArtifact : Singleton<UIArtifact>
             }
         }
     }
-
-    #region Drag and Drop Private
-
-    private ArtifactTileButton GetButtonHovered(PointerEventData data)
-    {
-        ArtifactTileButton hovered = null;
-        if (data.pointerEnter != null && data.pointerEnter.name == "Image")
-        {
-            hovered = data.pointerEnter.transform.parent.gameObject.GetComponent<ArtifactTileButton>();
-        }
-        return hovered;
-    }
-
-    private void SetButtonVisualsDuringMouseDrag(ArtifactTileButton dragged, ArtifactTileButton hovered)
-    {
-        foreach (ArtifactTileButton b in GetMoveOptions(dragged))
-        {
-            if (b == hovered)
-            {
-                b.SetHighlighted(false);
-                b.SetSpriteToHover();
-            }
-            else
-            {
-                b.SetHighlighted(true);
-                b.SetSpriteToIslandOrEmpty();
-            }
-        }
-    }
-
-    private void DoButtonDrag(ArtifactTileButton dragged, ArtifactTileButton hovered, List<ArtifactTileButton> moveOptions)
-    {
-        //Debug.Log($"dragged: {dragged.islandId} hovered: {hovered.islandId}");
-        if (!hovered.TileIsActive)
-        {
-            hovered.SetSpriteToEmpty();
-        }
-
-        foreach (ArtifactTileButton b in moveOptions)
-        {
-            b.SetHighlighted(false);
-            if (b == hovered)
-            {
-                SelectButton(hovered, true);
-                DeselectSelectedButton();
-                return;
-            }
-        }
-        SelectButton(dragged, true);
-
-        OnButtonInteract?.Invoke(this, null);
-    }
 }
-#endregion
+


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->
changed some stuff in ui artifact to make tiles execute faster as u queue more of them
## Description
<!--- Describe your changes in detail -->
added a counter that increases whenever a move is executed that then affects the duration property of the next smove and animation duration = move duration * base duration. also when you try dragging with automove, it automoves if the thing ur cursor is hovering is the same stile. if u dont hover over an stile then the highlighting goes away
Also apparently raycast targets mess this up so i removed that 💀 
## Related Task
<!--- What is the related trello task for this PR -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
