### PR TITLE
Add BindingHeldBehavior to Controls and use it for Village camera dolly skip

### DIFF
--- a/Slider/Assets/Scripts/Effects/CameraDolly.cs
+++ b/Slider/Assets/Scripts/Effects/CameraDolly.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Cinemachine;
+using UnityEngine.InputSystem;
 
 public class CameraDolly : MonoBehaviour
 {
@@ -13,6 +14,8 @@ public class CameraDolly : MonoBehaviour
     public AnimationCurve pathMovementCurve;
     public float duration;
 
+    private BindingHeldBehavior dollySkipBindingBehavior;
+
     private void Awake() 
     {
         dolly = virtualCamera.GetCinemachineComponent<CinemachineTrackedDolly>();
@@ -22,6 +25,10 @@ public class CameraDolly : MonoBehaviour
     public void StartTrack()
     {
         virtualCamera.Priority = 15;
+
+        dollySkipBindingBehavior = (BindingHeldBehavior) Controls.RegisterBindingBehavior(
+            new BindingHeldBehavior(Controls.Bindings.Player.Action, SkipToEndOfTrack, 1.5f));
+
         StartCoroutine(Rollercoaster());
     }
     
@@ -57,8 +64,15 @@ public class CameraDolly : MonoBehaviour
             yield return null;
             t += Time.deltaTime;
         }
+    }
 
-        // EndTrack();
+    private void SkipToEndOfTrack(InputAction.CallbackContext ignored)
+    {
+        UIEffects.FadeToBlack(
+            () => EndTrack()
+        );
+        StopAllCoroutines(); // Stops the dolly movement and prevents FadeToBlack from being called twice
+        Controls.UnregisterBindingBehavior(dollySkipBindingBehavior);
     }
 
     private void EndTrack()


### PR DESCRIPTION
## Description
Adds BindingHeldBehaviors to Controls which allow for triggering a callback when a control is held for a certain amount of time. Used this new functionality to allow skipping the Village intro camera dolly by holding down the Player.Action control for a short time.

## Related Task
None?

## How Has This Been Tested?
Held down button during intro dolly and observed that dolly was skipped. Tapped button and observed that dolly was not skipped. Tapped, released, then held button and observed that it was still not skipped. 