### PR TITLE
Update interactions to be prioritized over dropping items

### DIFF
--- a/Slider/Assets/Scripts/Player/IInteractable.cs
+++ b/Slider/Assets/Scripts/Player/IInteractable.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IInteractable
+{
+    /// <returns>Whether the action was successful or not</returns>
+    public bool Interact();
+
+    public int InteractionPriority { get => 0; }
+
+    public bool DisplayInteractionPrompt { get => true; }
+}

--- a/Slider/Assets/Scripts/Player/IInteractable.cs.meta
+++ b/Slider/Assets/Scripts/Player/IInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 137ccb62a3f34bb4b851e3ab1c830982
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Slider/Assets/Scripts/Utility/Control/PlayerConditionals.cs
+++ b/Slider/Assets/Scripts/Utility/Control/PlayerConditionals.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
-public class PlayerConditionals : MonoBehaviour
+public class PlayerConditionals : MonoBehaviour, IInteractable
 {
 
     public UnityEvent onSuccess;
@@ -13,28 +13,22 @@ public class PlayerConditionals : MonoBehaviour
     public bool isCarryingItem;
     public string itemNameCheck;
 
-    private bool actionAdded;
     private bool onActionEnabled = true;
-
-    // private void OnDisable() {               Maybe this is needed?
-    //     PlayerAction.OnAction -= OnActionListener;
-    // }
 
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (other.CompareTag("Player"))
         {
-            // Debug.Log("Adding listener!");
             if (addToOnAction)
             {
                 if (onActionEnabled)
                 {
-                    AddAction();
+                    Player.GetPlayerAction().AddInteractable(this);
                 }
             }
             else
             {
-                CheckCondition(); // might need to be Player.OnUpdate or something
+                CheckCondition();
             }
         }
     }
@@ -43,12 +37,11 @@ public class PlayerConditionals : MonoBehaviour
     {
         if (other.CompareTag("Player"))
         {
-            // Debug.Log("Removing listener!");
             if (addToOnAction)
             {
                 if (onActionEnabled)
                 {
-                    RemoveAction();
+                    Player.GetPlayerAction().RemoveInteractable(this);
                 }
             }
         }
@@ -102,33 +95,13 @@ public class PlayerConditionals : MonoBehaviour
     {
         if (addToOnAction && onActionEnabled)
         {
-            RemoveAction();
+            Player.GetPlayerAction().RemoveInteractable(this);
             onActionEnabled = false;
         }
     }
 
-    private void OnActionListener(object sender, System.EventArgs e)
+    public bool Interact()
     {
-        CheckCondition();
-    }
-
-    private void AddAction()
-    {
-        if (!actionAdded)
-        {
-            actionAdded = true;
-            PlayerAction.OnAction += OnActionListener;
-            Player.GetPlayerAction().IncrementActionsAvailable();
-        }
-    }
-
-    private void RemoveAction()
-    {
-        if (actionAdded)
-        {
-            actionAdded = false;
-            PlayerAction.OnAction -= OnActionListener;
-            Player.GetPlayerAction().DecrementActionsAvailable();
-        }
+        return CheckCondition();
     }
 }


### PR DESCRIPTION
## Description
Updates interaction code to have PlayerAction track a list of available interactables and interact with all of them that are tied for highest priority when the interact button is pressed. Also establishes a priority for interacting and item picking up/dropping:
**Picking Up Item = Interacting > Dropping**
This means that you can pick up an item and interact (e.g. talk to an NPC) at the same time with one button press but will not drop an item if you interact with something.

As a side effect, we also now have the . . . prompt for talking to NPCs when there is more dialogue to show.

## Related Task
[Make it so pressing "Action" prioritizes actions over throwing item](https://trello.com/c/fT1rYnXk)

## How Has This Been Tested?
Picked up the Anchor and tried talking to NPCs, going through doors, etc. Also tried holding an Anchor and picking up another Anchor nearby. Also tried going through a door when an Anchor was next to it (result: picked up the Anchor and moved through the door.)
