### PR TITLE
Ocean polish: making anchor easier to figure out for the player

### DIFF
--- a/Slider/Assets/Scripts/Map/Ocean/NPCRotation.cs
+++ b/Slider/Assets/Scripts/Map/Ocean/NPCRotation.cs
@@ -28,7 +28,7 @@ public class NPCRotation : MonoBehaviour
     [SerializeField] Transform IkeSpot; //ike
 
     public bool gotBreadge = false; //saved in oceangrid.cs maybe need to update to Savable in the future
-    public bool gotCatbeardTreasure = false;
+    public bool unlockedAllSliders = false;
 
     public void OnEnable()
     {
@@ -99,14 +99,14 @@ public class NPCRotation : MonoBehaviour
                 rotationUpdates.Add("alien");
                 break;
 
-            case "Cat Beard's Treasure"://dice ppl leave
-                rotationUpdates.Add("diceGirl");
+            case "Cat Beard's Treasure": //catbeard joins
                 rotationUpdates.Add("catBeard");
-                gotCatbeardTreasure = true;
                 break;
 
-            case "A Magical Gem": //fezziwig joins
+            case "A Magical Gem": //fezziwig joins, dice ppl leave
+                rotationUpdates.Add("diceGirl");
                 rotationUpdates.Add("fezziwig");
+                unlockedAllSliders = true;
                 break;
             default:
                 break;
@@ -116,7 +116,7 @@ public class NPCRotation : MonoBehaviour
     public void UpdateTavern()
     {
         float rng = UnityEngine.Random.Range(0f, 1f);
-        if (rng < .1f && !gotBreadge && gotCatbeardTreasure)
+        if (rng < .1f && !gotBreadge && unlockedAllSliders)
         {
             traveling_merchant.Teleport(leftEntrance, false);
         }

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/OceanGrid.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/OceanGrid.cs
@@ -113,7 +113,7 @@ public class OceanGrid : SGrid
         base.Save();
         SaveSystem.Current.SetBool("oceanRJBottleDelivery", bottleManager.puzzleSolved);
         SaveSystem.Current.SetBool("oceanFoggyIslandReached", foggyCompleted);
-        SaveSystem.Current.SetBool("oceanCatbeardTreasureCollected", npcRotation.gotCatbeardTreasure);
+        SaveSystem.Current.SetBool("oceanUnlockedAllSliders", npcRotation.unlockedAllSliders);
         SaveSystem.Current.SetBool("oceanBreadgeCollected", npcRotation.gotBreadge);
     }
 
@@ -128,7 +128,7 @@ public class OceanGrid : SGrid
 
         bottleManager.puzzleSolved = profile.GetBool("oceanRJBottleDelivery");
         foggyCompleted = profile.GetBool("oceanFoggyIslandReached");
-        npcRotation.gotCatbeardTreasure = profile.GetBool("oceanCatbeardTreasureCollected");
+        npcRotation.unlockedAllSliders = profile.GetBool("oceanUnlockedAllSliders");
         npcRotation.gotBreadge = profile.GetBool("oceanBreadgeCollected");
 
     }

--- a/Slider/Assets/Scripts/UI/OceanShop/TavernPassManager.cs
+++ b/Slider/Assets/Scripts/UI/OceanShop/TavernPassManager.cs
@@ -199,12 +199,12 @@ public class TavernPassManager : MonoBehaviour, ISavable
         {
             case 0:
                 // Free Slider
-                SGrid.Current.CollectSTile(4);
+                SGrid.Current.CollectSTile(5);
                 break;
 
             case 1:
                 // All Sliders
-                for (int i = 5; i <= 9; i++)
+                for (int i = 4; i <= 9; i++)
                 {
                     SGrid.Current.CollectSTile(i);
                 }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
biggest things are: bob now gives out tile 5 instead of tile 4. this means the player has to complete fezzewig to unlock all the other tiles. 
Other thing is now mako has different dialogue thats more relevant and hints the player about using the anchor as well as suggesting that bob may know a thing or two


