### PR TITLE
Fix issues with NPC interaction when waitUntilPlayerAction is false

### DIFF
--- a/Slider/Assets/Scripts/NPCs/NPCDialogueContext.cs
+++ b/Slider/Assets/Scripts/NPCs/NPCDialogueContext.cs
@@ -188,11 +188,6 @@ internal class NPCDialogueContext : MonoBehaviourContextProvider<NPC>, IInteract
     {
         if (dialogueBoxIsActive)
         {
-            if (!CurrentDialogue().waitUntilPlayerAction)
-            {
-                Player.GetPlayerAction().RemoveInteractable(this);
-            }
-
             if (waitingForPlayerAction)
             {
                 waitingForPlayerAction = false;


### PR DESCRIPTION
## Description
Removes extraneous code that would remove an NPC from the player's interactable list when waitUntilPlayerAction was false. This caused issues and is no longer needed anyway due to changes since the initial refactoring of player interaction.

## Related Task
Boomo's summons
