### PR TITLE
Rat Hot Fixes Before GDC

### DIFF
--- a/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
+++ b/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
@@ -70,8 +70,8 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
     {
         Vector2Int playerPosAsInt = TileUtil.WorldToTileCoords(ai.player.position);
         //Either the Rat can't get there, or it's the player (which the Rat should avoid at all costs!)
-        bool posIllegal = !ai.CostMap.ContainsKey(pt) || pt.Equals(playerPosAsInt);
-        if (posIllegal)
+        //bool posIllegal = !ai.CostMap.ContainsKey(pt)|| pt.Equals(playerPosAsInt);
+        if (pt.Equals(playerPosAsInt))
         {
             return int.MaxValue;
         } else
@@ -79,7 +79,7 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
             float distToPlayer = Vector2Int.Distance(playerPosAsInt, pt);
 
             //Total cost is the cost of the tile itself (based on how close it is to a wall) 
-            return ai.CostMap[pt] + ai.CostToThreat(distToPlayer, true);
+            return (int) (ai.paintedCostMap.GetNormalizedCostAt(pt) * ai.tileMaxPenalty) + ai.CostToThreat(distToPlayer, true);
         }
     }
 

--- a/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
+++ b/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
@@ -16,9 +16,9 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
     {
         int minCost = int.MaxValue;
         Vector2Int minCostPt = Vector2Int.zero;
-
         Vector2Int posAsInt = TileUtil.WorldToTileCoords(ai.transform.position);
 
+        //Find the position within maxDistVision with the lowest cost on the cost map
         float dist = 0f;
         var queue = new Queue<Vector2Int>();
         var visited = new HashSet<Vector2Int>();
@@ -53,6 +53,7 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
         }
         //Debug.Log($"Min Cost Neighbor: {minCostNeighbor} with cost {minCost}");
         
+        //Set destination to least cost pos, WorldNavigation takes care of the rest.
         if (minCost < int.MaxValue && !minCostPt.Equals(posAsInt))
         {
             RatBlackboard.Instance.destination = minCostPt;
@@ -64,11 +65,13 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
         }
     }
 
-    //Use this to get the cost to a point. (DON'T USE THIS TO GENERATE THE COST MAP)
+    //Total_Cost = Cost_Map_Cost + Player_Cost
     private int GetTileCost(Vector2Int pt)
     {
         Vector2Int playerPosAsInt = TileUtil.WorldToTileCoords(ai.player.position);
-        if (!ai.CostMap.ContainsKey(pt) || pt.Equals(playerPosAsInt))   //Either the Rat can't get there, or it's the player (which the Rat should avoid at all costs!)
+        //Either the Rat can't get there, or it's the player (which the Rat should avoid at all costs!)
+        bool posIllegal = !ai.CostMap.ContainsKey(pt) || pt.Equals(playerPosAsInt);
+        if (posIllegal)
         {
             return int.MaxValue;
         } else

--- a/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
+++ b/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToAvoidPlayerNode.cs
@@ -79,7 +79,15 @@ public class SetDestToAvoidPlayerNode : BehaviourTreeNode
             float distToPlayer = Vector2Int.Distance(playerPosAsInt, pt);
 
             //Total cost is the cost of the tile itself (based on how close it is to a wall) 
-            return (int) (ai.paintedCostMap.GetNormalizedCostAt(pt) * ai.tileMaxPenalty) + ai.CostToThreat(distToPlayer, true);
+            float normCost = ai.paintedCostMap.GetNormalizedCostAt(pt);
+            if (normCost > 1.5f)
+            {
+                return int.MaxValue;
+            }
+
+            int tileCost = (int) (ai.paintedCostMap.GetNormalizedCostAt(pt) * ai.tileMaxPenalty);
+            int playerCost = ai.CostToThreat(distToPlayer, true);
+            return tileCost + playerCost;
         }
     }
 

--- a/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToNearestValidPtNode.cs
+++ b/Slider/Assets/Scripts/AI/Behaviour Trees/CustomNodes/SetDestToNearestValidPtNode.cs
@@ -15,7 +15,7 @@ public class SetDestToNearestValidPtNode : BehaviourTreeNode
     public override NodeState Evaluate()
     {
         Vector2Int posAsInt = TileUtil.WorldToTileCoords(ai.transform.position);
-        if (ai.nav.IsValidPt(posAsInt) && (!ai.avoidsDark || LightManager.instance.GetLightMaskAt(posAsInt.x, posAsInt.y)))   //Rat is already standing in light
+        if (ai.nav.IsValidPt(posAsInt) && (!ai.avoidsDark || LightManager.instance.GetLightMaskAt(posAsInt.x, posAsInt.y)))
         {
             return NodeState.FAILURE;
         }

--- a/Slider/Assets/Scripts/AI/Pathfinding/WorldNavigation.cs
+++ b/Slider/Assets/Scripts/AI/Pathfinding/WorldNavigation.cs
@@ -194,18 +194,10 @@ public class WorldNavigation : MonoBehaviour
         return pos + new Vector2(stile.transform.position.x, stile.transform.position.y);
     }
 
-    private Vector2Int AbsToRelPos(Vector2 pos, STile stile)
-    {
-        Vector2 relPos = pos - new Vector2(stile.transform.position.x, stile.transform.position.y);
-        return TileUtil.WorldToTileCoords(relPos);
-    }
-
     private Vector2Int AbsToRelPos(Vector2Int pos, STile stile)
     {
         return pos - TileUtil.WorldToTileCoords(stile.transform.position);
     }
-
-
 
     //Check if a point is in.
     public bool IsValidPt(Vector2Int pos)
@@ -457,6 +449,11 @@ public class WorldNavigation : MonoBehaviour
 
     private void OnDrawGizmosSelected()
     {
+        if (stiles == null)
+        {
+            stiles = GetComponentsInChildren<STile>();
+        }
+
         if (validPtsWorld != null && stiles.Length > 0)
         {
             ForEachValidPtOutsideStile ((pos) => {

--- a/Slider/Assets/Scripts/AI/Rat/RatAI.cs
+++ b/Slider/Assets/Scripts/AI/Rat/RatAI.cs
@@ -80,8 +80,9 @@ public class RatAI : MonoBehaviour
     }
 
     //Costs for running away from player
-    public Dictionary<Vector2Int, int> CostMap { 
-        get { return _costMap; } 
+    public Dictionary<Vector2Int, int> CostMap
+    {
+        get { return _costMap; }
         private set { _costMap = value; }
     }
     private Dictionary<Vector2Int, int> _costMap = null;
@@ -243,6 +244,7 @@ public class RatAI : MonoBehaviour
         {
             _costMap = new Dictionary<Vector2Int, int>();
             Vector2Int posAsInt = TileUtil.WorldToTileCoords(transform.position);
+
             //Square that includes Rat vision (which itself is a circle)
             for (int x = (int)-maxDistVision; x <= (int)maxDistVision; x++)
             {
@@ -274,60 +276,9 @@ public class RatAI : MonoBehaviour
         return cost;
     }
 
-    //This algorithm essentially checks the given pos, it's neighbors, the neighbors' neighbors, and so on moving outwards from the original pos.
-    //Efficiency: (2*maxDistCost+1)^2
-    private float GetDistToNearestBadTile(Vector2Int posAsInt)
-    {
-        float distToNearestObstacle = float.MaxValue;
-        Vector2Int[] neighborDirs = { Vector2Int.up, Vector2Int.left, Vector2Int.down, Vector2Int.right,
-                                      new Vector2Int(1, 1), new Vector2Int(1, -1), new Vector2Int(-1, 1), new Vector2Int(-1, -1) };
-
-        float dist = 0f;
-        var queue = new Queue<Vector2Int>();
-        var visited = new HashSet<Vector2Int>();
-        visited.Add(posAsInt);
-        queue.Enqueue(posAsInt);
-        while (queue.Count > 0 && dist < maxDistCost)
-        {
-            Vector2Int currPos = queue.Dequeue();
-
-            foreach (var dir in neighborDirs)
-            {
-                Vector2Int posToCheck = currPos + dir;
-                if (!visited.Contains(posToCheck))
-                {
-                    float distToPoint = Vector2Int.Distance(posAsInt, currPos);
-                    dist = Mathf.Max(dist, distToPoint);
-                    visited.Add(posToCheck);
-                    queue.Enqueue(posToCheck);
-
-                    //Check wall, darkness, etc.
-                    bool darkObstacle = avoidsDark && !LightManager.instance.GetLightMaskAt(posToCheck.x, posToCheck.y);
-                    if ((!nav.IsValidPtOnStile(posToCheck) || darkObstacle) && distToPoint < distToNearestObstacle)
-                    {
-                        distToNearestObstacle = distToPoint;
-                    }
-                }
-
-            }
-        }
-
-        return distToNearestObstacle;
-    }
-
     private void OnDrawGizmosSelected()
-    {
-        /*
-        if (visited != null)
-        {
-            foreach (Vector2Int pt in visited)
-            {
-                Gizmos.color = Color.blue;
-                Gizmos.DrawSphere(new Vector3(pt.x, pt.y, 0), 0.2f);
-            }
-        }
-        */
-        
+    {   
+        //PRINT COST MAP
         if (CostMap != null)
         {
             foreach (Vector2Int pt in CostMap.Keys)

--- a/Slider/Assets/Scripts/AI/Rat/RatAI.cs
+++ b/Slider/Assets/Scripts/AI/Rat/RatAI.cs
@@ -80,12 +80,12 @@ public class RatAI : MonoBehaviour
     }
 
     //Costs for running away from player
-    public Dictionary<Vector2Int, int> CostMap
-    {
-        get { return _costMap; }
-        private set { _costMap = value; }
-    }
-    private Dictionary<Vector2Int, int> _costMap = null;
+    //public Dictionary<Vector2, int> CostMap
+    //{
+    //    get { return _costMap; }
+    //    private set { _costMap = value; }
+    //}
+    //private Dictionary<Vector2, int> _costMap = null;
 
     [HideInInspector]
     internal HashSet<Vector2Int> visited = null;    //For debugging
@@ -137,7 +137,7 @@ public class RatAI : MonoBehaviour
     {
         behaviourTree.Evaluate();
 
-        GenerateCostMap();
+        //GenerateCostMap();
 
         float distToPlayer = Vector3.Distance(transform.position, Player.GetPosition());
         float speed = Mathf.Lerp(maxSpeed, minSpeed, (distToPlayer - 1) / playerDeaggroRange);
@@ -164,10 +164,10 @@ public class RatAI : MonoBehaviour
         {
             transform.SetParent(currentStileUnderneath.transform);
         }
-        else
-        {
-            transform.SetParent(GameObject.Find("World Grid").transform);
-        }
+        //else (DON"T, JUST DON"T)
+        //{
+        //    transform.SetParent(GameObject.Find("World Grid").transform);
+        //}
 
         anim.SetFloat("speed", rb.velocity.magnitude);
     }
@@ -233,36 +233,43 @@ public class RatAI : MonoBehaviour
         var runFromPlayerSequence = new SequenceNode(new List<BehaviourTreeNode> { playerAggroNode, setDestToAvoidPlayerNode, moveTowardsSetDestNode });
         var runToValidPtSequence = new SequenceNode(new List<BehaviourTreeNode> { setDestToNearestValidPtNode, moveTowardsSetDestNode });
 
-        behaviourTree = new SelectorNode(new List<BehaviourTreeNode> { stealSequence, runFromPlayerSequence, runToValidPtSequence, stayInPlaceNode }); 
+        behaviourTree = new SelectorNode(new List<BehaviourTreeNode> { stealSequence, runToValidPtSequence, runFromPlayerSequence, stayInPlaceNode }); 
 
     }
 
     //Efficiency: (2*maxDistVision+1)^2 * (2*maxDistCostmap+1)^2 (This is the most costly operation in the AI)
-    private void GenerateCostMap()
-    {
-        if (!avoidsDark || LightManager.instance != null)
-        {
-            _costMap = new Dictionary<Vector2Int, int>();
-            Vector2Int posAsInt = TileUtil.WorldToTileCoords(transform.position);
+    //private void GenerateCostMap()
+    //{
+    //    if (!avoidsDark || LightManager.instance != null)
+    //    {
+    //        _costMap = new Dictionary<Vector2, int>();
+    //        Vector2Int posAsInt = TileUtil.WorldToTileCoords(transform.position);
 
-            //Square that includes Rat vision (which itself is a circle)
-            for (int x = (int)-maxDistVision; x <= (int)maxDistVision; x++)
-            {
-                for (int y = (int)-maxDistVision; y <= (int)maxDistVision; y++)
-                {
-                    Vector2Int pos = posAsInt + new Vector2Int(x, y);
-                    if (nav.IsValidPtOnStile(pos) && (!avoidsDark || LightManager.instance.GetLightMaskAt(pos.x, pos.y)))
-                    {
-                        int cost = (int)(tileMaxPenalty * paintedCostMap.GetNormalizedCostAt(pos));
-                        // int cost = CostToThreat(GetDistToNearestBadTile(pos), false);
-                        _costMap.Add(pos, cost);
-                    }
-                }
-            }
-        }
+    //        //Square that includes Rat vision (which itself is a circle)
+    //        for (int x = (int)-maxDistVision; x <= (int)maxDistVision; x++)
+    //        {
+    //            for (int y = (int)-maxDistVision; y <= (int)maxDistVision; y++)
+    //            {
+    //                Vector2Int pos = posAsInt + new Vector2Int(x, y);
 
-        Debug.Assert(_costMap != null, "Tried to initialize Cost Map before LightManager. This might be a problem.");
-    }
+    //                bool tileLightingValid = (!avoidsDark || LightManager.instance.GetLightMaskAt(pos.x, pos.y));
+    //                if (nav.IsValidPtOnStile(pos) && tileLightingValid)
+    //                {
+    //                    float normCost = paintedCostMap.GetNormalizedCostAt(pos);
+    //                    if (normCost <= 1.5f) //Cost can be > 1 to indicate untraversable ground.
+    //                    {
+    //                        int cost = (int)(tileMaxPenalty*normCost);
+    //                        // int cost = CostToThreat(GetDistToNearestBadTile(pos), false);
+    //                        _costMap.Add(pos, cost);
+    //                    }
+
+    //                }
+    //            }
+    //        }
+    //    }
+
+    //    Debug.Assert(_costMap != null, "Tried to initialize Cost Map before LightManager. This might be a problem.");
+    //}
 
     internal int CostToThreat(float distToThreat, bool threatIsPlayer)
     {
@@ -279,22 +286,21 @@ public class RatAI : MonoBehaviour
     private void OnDrawGizmosSelected()
     {   
         //PRINT COST MAP
-        if (CostMap != null)
-        {
-            foreach (Vector2Int pt in CostMap.Keys)
-            {
-                if (CostMap[pt] == int.MaxValue)
-                {
-                    Gizmos.color = Color.red;
-                } else
-                {
-                    //Debug.Log($"CostMap in OnDrawGizmosSelected: {CostMap[pt]}");
-                    Gizmos.color = Color.Lerp(Color.green, Color.red, (float) CostMap[pt] / tileMaxPenalty);
-                }
+        //if (CostMap != null)
+        //{
+        //    foreach (Vector2Int pt in CostMap.Keys)
+        //    {
+        //        if (CostMap[pt] == int.MaxValue)
+        //        {
+        //            Gizmos.color = Color.red;
+        //        } else
+        //        {
+        //            //Debug.Log($"CostMap in OnDrawGizmosSelected: {CostMap[pt]}");
+        //            Gizmos.color = Color.Lerp(Color.green, Color.red, (float) CostMap[pt] / tileMaxPenalty);
+        //        }
 
-                Gizmos.DrawSphere(new Vector3(pt.x, pt.y, 0), 0.2f);
-            }
-        }
-        
+        //        Gizmos.DrawSphere(new Vector3(pt.x, pt.y, 0), 0.2f);
+        //    }
+        //}     
     }
 }

--- a/Slider/Assets/Scripts/Map/PaintedCostMap.cs
+++ b/Slider/Assets/Scripts/Map/PaintedCostMap.cs
@@ -5,6 +5,7 @@ public class PaintedCostMap : MonoBehaviour
 {
     [SerializeField] private PaintedSTileCostMap[] stileCostMaps;
     [SerializeField] private TileBase[] weightTiles;
+    [SerializeField] private STile[] stiles;
 
     private int stileWidth;
 
@@ -17,7 +18,9 @@ public class PaintedCostMap : MonoBehaviour
     {
         STile stile = GetStileAt(worldCoords);
         if (stile == null)
-            return 1;
+        {
+            return 2;   //Tile untraversable.
+        }
         
         PaintedSTileCostMap stileCostMap = stileCostMaps[stile.islandId - 1];
         int stilePositionX = (int)(worldCoords.x - stile.transform.position.x - 0.5f);
@@ -43,21 +46,32 @@ public class PaintedCostMap : MonoBehaviour
         return tileIndex / (weightTiles.Length - 1.0f);
     }
 
-    // Returns island id
     private STile GetStileAt(Vector2 worldCoords)
     {
-        int stileX = (int)((worldCoords.x + (stileWidth / 2) + 0.5f) / stileWidth);
-        int stileY = (int)((worldCoords.y + (stileWidth / 2) + 0.5f) / stileWidth);
-
-        STile stile = SGrid.Current.GetStileAt(stileX, stileY);
-
-        if (stile.isTileActive && !stile.IsMoving())
+        float halfWidth = (float) stileWidth / 2;
+        foreach (STile st in stiles)
         {
-            return stile;
+            float dx = worldCoords.x - st.transform.position.x;
+            float dy = worldCoords.y - st.transform.position.y;
+            if (dx >= -halfWidth && dx <= halfWidth && dy >= -halfWidth && dy <= halfWidth) {
+                return st;
+            }
         }
 
-        // else look for the moving stile
-
+        //Debug.LogError("Couldn't Find Stile for Painted Cost Map (this shouldn't happen?)");
         return null;
+
+        //int stileX = (int)((worldCoords.x + halfWidth + 0.5f) / stileWidth);
+        //int stileY = (int)((worldCoords.y + halfWidth + 0.5f) / stileWidth);
+
+        //STile stile = SGrid.Current.GetStileAt(stileX, stileY);
+
+        //if (stile.isTileActive && !stile.IsMoving())
+        //{
+        //    return stile;
+        //}
+
+        //// else look for the moving stile
+        //return null;
     }
 }

--- a/Slider/Assets/Scripts/Map/PaintedCostMap.cs
+++ b/Slider/Assets/Scripts/Map/PaintedCostMap.cs
@@ -35,7 +35,10 @@ public class PaintedCostMap : MonoBehaviour
         }
 
         if (tileIndex == -1)
-            return 1;
+        {
+            //Tile is untraversable.
+            return 2;
+        }
 
         return tileIndex / (weightTiles.Length - 1.0f);
     }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Made some adjustments to the costmap
- Commented out code that unparented the rat from tiles since we don't do that anymore anyway.
- Removed cost map generation since it happens every frame anyway and we already have the costmap (might want to add back. Idk which is actually faster).
- Switched the order of behaviour nodes so that it moves to the nearest valid tile first before avoiding the player (fixes stalling issues I think, it didn't break the movement when I tested it).
- Changed stile getter in PaintedCostMap.cs to handle moves (linear search, but it's honestly not much slower). 

## Related Task
<!--- What is the related trello task for this PR -->
idk

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
idk

## Screenshots (if appropriate):
I'm too lazy and gdc is tomo.
