### PR TITLE
Changes Player Winning text prompt to rely on jungleChadSpeak var instead of typing the text in Unity Editor

### DIFF
--- a/Slider/Assets/Scripts/Map/Puzzles/ChadRace.cs
+++ b/Slider/Assets/Scripts/Map/Puzzles/ChadRace.cs
@@ -111,7 +111,6 @@ public class ChadRace : MonoBehaviour
                 ActivateSpeedLines(true);
                 if (!tilesAdjacent) {
                     // The player has cheated
-                    // TODO: Record Scratch stuff should start around here.
                     AudioManager.Play("Record Scratch");
                     chadEndLocal = transform.localPosition;
                     DisplayAndTriggerDialogue("Hey, no changing the track before the race is done!");
@@ -191,6 +190,7 @@ public class ChadRace : MonoBehaviour
     public void PlayerEnteredEnd() {
         if (raceState == State.Running) {
             raceState = State.PlayerWon;
+            DisplayAndTriggerDialogue("Dangit, I don't know how you won, especially with my faster boots.");
             onRaceWon.Invoke();
         }
     }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Player-winning text prompt rendered using `DisplayAndTriggerDialogue()` function in `ChadRace.cs` rather than in Unity Editor

## Related Task
<!--- What is the related trello task for this PR -->
chad race cheating player feedback systems so you know if youre racing or not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Navigate to Assets/Scenes/Dev/Avery/ and start the Jungle Scene
- Race Chad and win, observe the bug as Chad approaches

## Screenshots (if appropriate):
