### PR TITLE
Mirage Tile Fixes

### DIFF
--- a/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
@@ -8,7 +8,21 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
 {
 
     [SerializeField] private List<GameObject> mirageSTiles;
+    [SerializeField] private List<ArtifactTBPluginMirage> mirageButtons;
     public static Vector2Int mirageTailPos;
+
+    //struct MirageEnableArgs
+    //{
+    //    public int islandId, x, y;
+
+    //    public MirageEnableArgs(int islandId, int x, int y)
+    //    {
+    //        this.islandId = islandId;
+    //        this.x = x;
+    //        this.y = y;
+    //    }
+    //}
+    //private Queue<MirageEnableArgs> mirageEnableQueue;
 
     /// <summary>
     /// The scale factor from the position of a tile on the grid to the transform.position of the tile.
@@ -20,11 +34,37 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
     {
         InitializeSingleton();
         mirageTailPos = new Vector2Int(-1, -1);
+        //mirageEnableQueue = new Queue<MirageEnableArgs>();
+    }
+
+    private void OnEnable()
+    {
+        SGridAnimator.OnSTileMoveEndLate += OnSTileMoveEndLate;
+    }
+    private void OnDisable()
+    {
+        SGridAnimator.OnSTileMoveEndLate -= OnSTileMoveEndLate;
+    }
+
+    private void OnSTileMoveEndLate(object sender, SGridAnimator.OnTileMoveArgs e)
+    {
+        if (!SaveSystem.Current.GetBool("desertMirage")) return; //Maybe add a collectible check?
+        Debug.Log("STileMoveEndLateCalled");
+        if (UIArtifact.GetInstance().MoveQueueEmpty())
+        {
+            //No new moves should be queued before mirage tiles are enabled
+            foreach (ArtifactTBPluginMirage button in mirageButtons)
+            {
+                var buttonBase = button.GetComponent<ArtifactTileButton>();
+                EnableMirage(button.mirageIslandId, buttonBase.x, buttonBase.y);
+            }
+  
+        }
     }
 
     public void EnableMirage(int islandId, int x, int y)
     {
-        if (islandId > 7) return;
+        if (islandId > 7 || islandId < 1) return;
         //Do some STile collider crap
         mirageSTiles[islandId - 1].transform.position = new Vector2(x * GRID_POSITION_TO_WORLD_POSITION, y * GRID_POSITION_TO_WORLD_POSITION);
         mirageSTiles[islandId - 1].gameObject.SetActive(true);
@@ -45,15 +85,28 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
         int mirageIsland;
         if (isPlayerOnMirage(out mirageIsland))
         {
-            //Debug.Log($"Player on Mirage! Current mirage: {mirageIsland}");
+            Debug.Log($"Player on Mirage! Current mirage: {mirageIsland}");
             //Player.GetInstance().transform.SetParent(grid.GetStile(mirageIsland).transform, false);
+            Debug.Log($"{mirageIsland} == {islandId}?");
+            if (mirageIsland == islandId)
+            {
+                Debug.Log(mirageIsland);
+                //The mirage that just got disabled (player could be on enabled tile)
+                STile realSTile = DesertGrid.Current.GetStile(islandId);
+                Vector3 relativePos = Player._instance.transform.position - mirageSTiles[islandId - 1].transform.position;
+                Player.SetPosition(realSTile.transform.position + relativePos);
+
+                //Play the funny sound, maybe make it more "mystical" or something idk.
+                AudioManager.Play("Hurt");
+                UIEffects.FadeFromBlack(null, 1.5f);
+            }
         }
         //Insert disable effect
         if (islandId == 0 || islandId > 7) return;
         if (islandId < 0) foreach (GameObject o in mirageSTiles) o.SetActive(false);
         //if (islandId == 7) mirageTailPos = new Vector2Int(-1, -1);
         else mirageSTiles[islandId - 1].gameObject.SetActive(false);
-        Debug.Log(mirageTailPos);
+        //Debug.Log(mirageTailPos);
     }
 
     /// <summary>
@@ -100,7 +153,7 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
             if (stilePos.x - offset < pos.x && pos.x < stilePos.x + offset &&
             (stilePos.y - offset < pos.y && pos.y < stilePos.y + offset))
             {
-               islandId = i;
+               islandId = i+1;
                return true;
             }
         }

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
@@ -35,6 +35,8 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
         InitializeSingleton();
         mirageTailPos = new Vector2Int(-1, -1);
         //mirageEnableQueue = new Queue<MirageEnableArgs>();
+
+        mirageButtons = UIArtifact._instance.transform.parent.GetComponentsInChildren<ArtifactTBPluginMirage>().ToList();
     }
 
     private void OnEnable()

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaSTiles/MirageSTileManager.cs
@@ -51,7 +51,7 @@ public class MirageSTileManager : Singleton<MirageSTileManager>
         //Insert disable effect
         if (islandId == 0 || islandId > 7) return;
         if (islandId < 0) foreach (GameObject o in mirageSTiles) o.SetActive(false);
-        if (islandId == 7) mirageTailPos = new Vector2Int(-1, -1);
+        //if (islandId == 7) mirageTailPos = new Vector2Int(-1, -1);
         else mirageSTiles[islandId - 1].gameObject.SetActive(false);
         Debug.Log(mirageTailPos);
     }

--- a/Slider/Assets/Scripts/Sliders/Grid/SGridAnimator.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/SGridAnimator.cs
@@ -16,6 +16,7 @@ public class SGridAnimator : MonoBehaviour
     public static event System.EventHandler<OnTileMoveArgs> OnSTileMoveStart;
     public static event System.EventHandler<OnTileMoveArgs> OnSTileMoveEndEarly;
     public static event System.EventHandler<OnTileMoveArgs> OnSTileMoveEnd;
+    public static event System.EventHandler<OnTileMoveArgs> OnSTileMoveEndLate; //:clown emoji
 
     // set in inspector
     public AnimationCurve movementCurve;
@@ -180,7 +181,15 @@ public class SGridAnimator : MonoBehaviour
             smove = move,
             moveDuration = currMoveDuration
         });
-        
+
+        OnSTileMoveEndLate?.Invoke(this, new OnTileMoveArgs
+        {
+            stile = stile,
+            prevPos = moveCoords.startLoc,
+            smove = move,
+            moveDuration = currMoveDuration
+        });
+
         EffectOnMoveFinish(move, moveCoords, isPlayerOnStile ? null : stile.transform, stile, playSound);
     }
     

--- a/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/DesertArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/AreaArtifacts/DesertArtifact.cs
@@ -189,10 +189,10 @@ public class DesertArtifact : UIArtifact
             return;
         }
         List<ATBPair> pairs = storedSwaps.Dequeue();
-        Debug.Log($"# moves remaining: {storedSwaps.Count}");
+        //Debug.Log($"# moves remaining: {storedSwaps.Count}");
         foreach (ATBPair s in pairs)
         {
-            Debug.Log($"current: {s.current} furthest: {s.furthest} \n target pos: {s.furthest.x}{s.furthest.y}");
+            //Debug.Log($"current: {s.current} furthest: {s.furthest} \n target pos: {s.furthest.x}{s.furthest.y}");
             SwapButtons(s.current, s.furthest);
         }
     }

--- a/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginMirage.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginMirage.cs
@@ -48,7 +48,8 @@ public class ArtifactTBPluginMirage : ArtifactTBPlugin
             buttonMirage.SetMirageEnabled(true);
         }
         //Enable STile
-        MirageSTileManager.GetInstance().EnableMirage(mirageIslandId, cords.Item1, cords.Item2);
+        //MirageSTileManager.GetInstance().EnableMirage(mirageIslandId, cords.Item1, cords.Item2);
+        //MirageSTileManager.GetInstance().QueueMirage(mirageIslandId, cords.Item1, cords.Item2);
     }
 
     private void DisableMirage()

--- a/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginMirage.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginMirage.cs
@@ -24,8 +24,8 @@ public class ArtifactTBPluginMirage : ArtifactTBPlugin
         if (mirageIslandId > 0)
         {
             //Debug.Log("disablemirage");
-            DisableMirage();
-            return;
+            //DisableMirage();
+            //return;
         }
         //Debug.Log("selecting");
         button.SelectButton();


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Clicking the mirage tiles in the UI doesn't do anything anymore.
- Moving onto mirage tile is one click
- When player is on mirage tile and it gets disabled, they get pushed back to the same location on the real tile with blackout/sound effect.
- The mirage tile appears on move complete instead of immediately. I think it might look better if it faded into existence. It looked like Travis was working on something like this?

## Related Task
<!--- What is the related trello task for this PR -->
https://trello.com/c/CnMtA7vh/445-desert-mirage

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I tested that it worked with queueing a bunch of moves and different mirage tiles/smove combinations
- Fixed issue with player reparenting.
- There's another issue with dialogue boxes not disappearing on mirage tiles, but I think that's a separate issue.

## Screenshots (if appropriate):
![MirageTeleport](https://github.com/randomerz/Slider/assets/31969905/9e9d597a-1843-4183-9b6f-a11bf72de091)
