### PR TITLE
Gem Serialization

### DIFF
--- a/Slider/Assets/Scripts/Map/MagiTech/GemManager.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/GemManager.cs
@@ -10,6 +10,7 @@ public class GemManager : MonoBehaviour, ISavable
 
     public List<GameObject> sprites = new();
     public List<Transform> poofTransforms = new();
+    [Tooltip("Put in world progression order (Village->Caves)")]
     public List<Item> gemItems = new();
 
     private bool hasGemTransporter;
@@ -53,6 +54,7 @@ public class GemManager : MonoBehaviour, ISavable
 
         BuildSpriteDictionary();
         UpdateGemSprites();
+        UpdateGemItems();
 
         if(profile.GetBool("MagitechHasGemTransporter"))
             EnableGemTransporter();
@@ -72,7 +74,10 @@ public class GemManager : MonoBehaviour, ISavable
     public void HasDesertGem(Condition c) => c.SetSpec(gems.GetValueOrDefault(Area.Desert, false));
     public void HasJungleGem(Condition c) => c.SetSpec(gems.GetValueOrDefault(Area.Jungle, false));
     public void HasMagiTechGem(Condition c) => c.SetSpec(gems.GetValueOrDefault(Area.MagiTech, false));
-
+    public bool HasAreaGem(Area area)
+    {
+        return gems.GetValueOrDefault(area, false);
+    }
     public void BuildSpriteDictionary()
     {
         for(int i = 1; i <= sprites.Count; i++)
@@ -137,7 +142,20 @@ public class GemManager : MonoBehaviour, ISavable
             animator.Play("Active");
         }
     }
-
+    //Only affects gems enabled by default in MagiTech
+    private void UpdateGemItems()
+    {
+        if (gemItems.Count != 8)
+        {
+            Debug.LogWarning("gemItems not properly set in Inspector!");
+            return;
+        }
+        gemItems[1].gameObject.SetActive(!gems[Area.Caves]);
+        gemItems[2].gameObject.SetActive(!gems[Area.Ocean]);
+        gemItems[3].gameObject.SetActive(!gems[Area.Jungle]);
+        gemItems[6].gameObject.SetActive(!gems[Area.Military]);
+        gemItems[7].gameObject.SetActive(!gems[Area.MagiTech]);
+    }
     private bool HasAllGems()
     {
         foreach (bool b in gems.Values)

--- a/Slider/Assets/Scripts/Map/MagiTech/MagiGem.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/MagiGem.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static UnityEditor.Progress;
 
 public class MagiGem : MonoBehaviour, ISavable
 {
@@ -24,6 +26,18 @@ public class MagiGem : MonoBehaviour, ISavable
     private void Start()
     {
         gemItem = GetComponent<Item>();
+    }
+
+    public void EnableGem()
+    {
+        if (Enum.TryParse(gemItem.itemName, out Area itemNameAsEnum))
+        {
+            gemItem.gameObject.SetActive(!gemMachine.HasAreaGem(itemNameAsEnum));
+        }
+        else if (gemItem.itemName == "Mountory")
+        {
+            gemItem.gameObject.SetActive(!gemMachine.HasAreaGem(Area.Mountain));
+        }   
     }
 
     public void TransportGem()


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added EnableGem function to allow NPCs to only enable if the player doesn't already have the gem.
Gems enabled by default are managed by MagiTech grid
Added dialogue options for Curator, Burger Guy, and VIP brother when the player has the gem (and the slider if the npc gives one)
## Related Task
<!--- What is the related trello task for this PR -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I grab gem, I load another scene, I come back
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/randomerz/Slider/assets/37708746/1c940b99-83fb-4a52-86a0-2c449a84df3f)
![image](https://github.com/randomerz/Slider/assets/37708746/190e6a8a-59e0-4e9d-9c7f-7df8d5e5167a)
![image](https://github.com/randomerz/Slider/assets/37708746/50ba6a81-746e-4da4-867b-f95cec54e2ad)
