### PR TITLE
Fix some magitech bugs

### DIFF
--- a/Slider/Assets/Scripts/Map/Interactable/Items/DesyncItem.cs
+++ b/Slider/Assets/Scripts/Map/Interactable/Items/DesyncItem.cs
@@ -81,7 +81,7 @@ public class DesyncItem : Item
     {
         if(!isDesynced && MagiTechGrid.IsTileDesynced(currentTile))
         {
-             isDesynced = true;
+            isDesynced = true;
             UpdateItemPair();
         }
     }
@@ -118,7 +118,7 @@ public class DesyncItem : Item
 
     private void OnDesyncStartWorld(object sender, MagiTechGrid.OnDesyncArgs e)
     {
-        isDesynced = currentTile.islandId == e.desyncIslandId;
+        isDesynced = currentTile.islandId == e.desyncIslandId || currentTile.islandId == e.anchoredTileIslandId;
         UpdateItemPair();
     }
 
@@ -133,7 +133,8 @@ public class DesyncItem : Item
         pastItem.UpdateLightning();
         bool presentShouldBeActive = presentItem.isDesynced || pastItem.isDesynced || pastItem.isItemInPast;
         if(presentItem.gameObject.activeSelf != presentShouldBeActive)
-        {
+        {   
+            //Todo: have particles/phantom effect/smth to show where object was
             presentItem.gameObject.SetActive(presentShouldBeActive);
             ParticleManager.SpawnParticle(ParticleType.SmokePoof, presentItem.transform.position);
         }

--- a/Slider/Assets/Scripts/Map/Interactable/Items/Item.cs
+++ b/Slider/Assets/Scripts/Map/Interactable/Items/Item.cs
@@ -9,7 +9,7 @@ public class Item : MonoBehaviour, ISavable
     public SpriteRenderer spriteRenderer;
     [SerializeField] protected Collider2D myCollider;
     public bool canKeep = false;
-    [SerializeField] private bool shouldDisableAtStart = false;
+    public bool shouldDisableAtStart = false;
     public bool doReflectionCalculations;
     public float itemRadius = 0.5f;
 

--- a/Slider/Assets/Scripts/Map/MagiTech/DesyncLever.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/DesyncLever.cs
@@ -41,12 +41,10 @@ public class DesyncLever : Lever
             leverPair.Switch();
         }
     }
-
-
     
     private void OnDesyncStartWorld(object sender, MagiTechGrid.OnDesyncArgs e)
     {
-        isDesynced = currentTile.islandId == e.desyncIslandId;
+        isDesynced = currentTile.islandId == e.desyncIslandId || currentTile.islandId == e.anchoredTileIslandId;
         lightning.SetActive(isDesynced);
     }
 

--- a/Slider/Assets/Scripts/Map/MagiTech/GemManager.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/GemManager.cs
@@ -56,7 +56,6 @@ public class GemManager : MonoBehaviour, ISavable
 
         BuildSpriteDictionary();
         UpdateGemSprites();
-        UpdateGemItems();
 
         if(profile.GetBool("MagitechHasGemTransporter"))
             EnableGemTransporter();
@@ -135,6 +134,8 @@ public class GemManager : MonoBehaviour, ISavable
 
     public void UpdateGemSprites()
     {
+        if(gemSprites == null || gemSprites.Keys.Count != 9)
+            BuildSpriteDictionary();
         UpdateNumRemainingGems();
         foreach(Area a in gems.Keys)
         {
@@ -146,20 +147,6 @@ public class GemManager : MonoBehaviour, ISavable
         }
     }
     
-    private void UpdateGemItems()
-    {
-        if (gemItems.Count != 8)
-        {
-            Debug.LogWarning("gemItems not properly set in Inspector!");
-            return;
-        }
-        gemItems[1].gameObject.SetActive(!gems[Area.Caves]);
-        gemItems[2].gameObject.SetActive(!gems[Area.Ocean]);
-        gemItems[3].gameObject.SetActive(!gems[Area.Jungle]);
-        gemItems[6].gameObject.SetActive(!gems[Area.Military]);
-        // gemItems[7].gameObject.SetActive(!gems[Area.MagiTech]);
-    }
-
     private void UpdateNumRemainingGems()
     {
         int num = 0;

--- a/Slider/Assets/Scripts/Map/MagiTech/MagiGem.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/MagiGem.cs
@@ -10,7 +10,17 @@ public class MagiGem : MonoBehaviour, ISavable
     private bool isTransporting;
     public GameObject particles;
 
-    public void Load(SaveProfile profile) {}
+    public void Load(SaveProfile profile) {
+        if(gemItem == null)
+        {
+            Debug.LogError("gem null on " + gameObject.name);
+            return;
+        }
+        if(!gemItem.shouldDisableAtStart)
+        {
+            EnableGem(); //if gem active by default, disable if already collected
+        }
+    }
 
     //fix edge cases for leaving scene
     public void Save()
@@ -20,11 +30,6 @@ public class MagiGem : MonoBehaviour, ISavable
             gemMachine.TransportGem(gemItem);
             gemMachine.Save();
         }
-    }
-
-    private void Start()
-    {
-        gemItem = GetComponent<Item>();
     }
 
     public void EnableGem()

--- a/Slider/Assets/Scripts/Map/MagiTech/MagiLaser.cs
+++ b/Slider/Assets/Scripts/Map/MagiTech/MagiLaser.cs
@@ -106,7 +106,7 @@ public class MagiLaser : MonoBehaviour, ISavable
 
             if (!laserable)
             {
-                Debug.LogWarning(hit + " does not have a Laserable component! Doing nothing");
+                Debug.LogWarning(hit.collider.gameObject.name + " does not have a Laserable component! Doing nothing");
                 return;
             }
 

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/MagiTechGrid.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/MagiTechGrid.cs
@@ -21,6 +21,12 @@ public class MagiTechGrid : SGrid
     //C: likewise this is the ID of the *opposite* Stile
     public int desyncIslandId = -1;
 
+    //Location of the anchored tile
+    public Vector2Int desyncAnchoredTileLocation = new Vector2Int(-1, -1);
+
+    //ID of anchored tile
+    public int desyncAnchoredIslandId = -1;
+
     //True when the opposite tile is at a different location
     public bool DesyncActive = false;
 
@@ -28,11 +34,15 @@ public class MagiTechGrid : SGrid
     {
         public int desyncIslandId;
         public Vector2Int desyncLocation;
+        public int anchoredTileIslandId;
+        public Vector2Int anchoredTileLocation;
 
-        public OnDesyncArgs(int desyncIslandId, Vector2Int desyncLocation)
+        public OnDesyncArgs(int desyncIslandId, Vector2Int desyncLocation, int anchoredTileIslandId, Vector2Int anchoredTileLocation)
         {
             this.desyncIslandId = desyncIslandId;
             this.desyncLocation = desyncLocation;
+            this.anchoredTileIslandId = anchoredTileIslandId;
+            this.anchoredTileLocation = anchoredTileLocation;
         }
     }
 
@@ -178,6 +188,8 @@ public class MagiTechGrid : SGrid
             {
                 desyncLocation = FindAltCoords(dropTile.x, dropTile.y);
                 desyncIslandId = FindAltId(dropTile.islandId);
+                desyncAnchoredTileLocation = new(dropTile.x, dropTile.y);
+                desyncAnchoredIslandId = dropTile.islandId;
             }
             else if (desyncIslandId != -1)
             {
@@ -190,9 +202,11 @@ public class MagiTechGrid : SGrid
     {
         RestoreGridFromDesync();
         DesyncActive = false;
-        OnDesyncEndWorld?.Invoke(this, new(desyncIslandId, desyncLocation));
+        OnDesyncEndWorld?.Invoke(this, new(desyncIslandId, desyncLocation, desyncAnchoredIslandId, desyncAnchoredTileLocation));
         desyncLocation = new Vector2Int(-1, -1);
         desyncIslandId = -1;
+        desyncAnchoredTileLocation = new Vector2Int(-1, -1);
+        desyncAnchoredIslandId = -1;
     }
 
     private void RestoreGridFromDesync()
@@ -237,7 +251,7 @@ public class MagiTechGrid : SGrid
             if(e.prevPos == desyncLocation) //moving away from "correct" location
             {
                 DesyncActive = true;
-                OnDesyncStartWorld?.Invoke(this, new(desyncIslandId, desyncLocation));
+                OnDesyncStartWorld?.Invoke(this, new(desyncIslandId, desyncLocation, desyncAnchoredIslandId, desyncAnchoredTileLocation));
             }
         }
     }
@@ -249,7 +263,7 @@ public class MagiTechGrid : SGrid
             if(e.stile.x == desyncLocation.x && e.stile.y == desyncLocation.y) //back to "correct" location
             {
                 DesyncActive = false;
-                OnDesyncEndWorld?.Invoke(this, new(desyncIslandId, desyncLocation));
+                OnDesyncEndWorld?.Invoke(this, new(desyncIslandId, desyncLocation, desyncAnchoredIslandId, desyncAnchoredTileLocation));
             }
         }
     }
@@ -258,7 +272,7 @@ public class MagiTechGrid : SGrid
     {
         if(tile == null) return false;
         var m = Current as MagiTechGrid;
-        return m.DesyncActive && m.desyncIslandId == tile.islandId;
+        return m.DesyncActive && (m.desyncIslandId == tile.islandId || m.desyncAnchoredIslandId == tile.islandId);
     }
 
 

--- a/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/MagiTechGrid.cs
+++ b/Slider/Assets/Scripts/Sliders/Grid/AreaGrids/MagiTechGrid.cs
@@ -51,7 +51,8 @@ public class MagiTechGrid : SGrid
 
     [SerializeField] private Collider2D fireStoolZoneCollider;
     [SerializeField] private Collider2D lightningStoolZoneCollider;
-    private int numOres = 0;
+
+    private int numOil = 0;
 
     [SerializeField] private MagiTechTabManager tabManager;
     [SerializeField] private PlayerActionHints hints;
@@ -156,6 +157,7 @@ public class MagiTechGrid : SGrid
         {
             EndDesync();
         }
+        SaveSystem.Current.SetInt("MagitechOilCollected", numOil);
         base.Save();
     }
 
@@ -166,6 +168,8 @@ public class MagiTechGrid : SGrid
             tabManager.EnableTab();
         if(profile.GetBool("magitechBridgeFixed"))
             LowerDrawbridge(true);
+        numOil = profile.GetInt("MagitechOilCollected");
+
     }
 
     public static bool IsInPast(Transform transform)
@@ -356,23 +360,23 @@ public class MagiTechGrid : SGrid
         return list;
     }
 
-    public void HasOneOre(Condition c)
+    public void HasOneOil(Condition c)
     {
-        c.SetSpec(numOres == 1);
+        c.SetSpec(numOil == 1);
     }
 
-    public void HasTwoOres(Condition c)
+    public void HasTwoOil(Condition c)
     {
-        c.SetSpec(numOres == 2);
+        c.SetSpec(numOil == 2);
     }
-    public void HasThreeOres(Condition c)
+    public void HasThreeOil(Condition c)
     {
-        c.SetSpec(numOres == 3);
+        c.SetSpec(numOil == 3);
     }
 
-    public void IncrementOres()
+    public void IncrementOil()
     {
-        numOres++;
+        numOil++;
     }
 
     public void IsDesyncActive(Condition c)
@@ -384,7 +388,8 @@ public class MagiTechGrid : SGrid
     {
         c.SetSpec(DesyncActive && 
         Player.GetInstance().GetSTileUnderneath() != null &&
-        Player.GetInstance().GetSTileUnderneath().islandId == desyncIslandId);
+        (Player.GetInstance().GetSTileUnderneath().islandId == desyncIslandId ||
+        Player.GetInstance().GetSTileUnderneath().islandId == desyncAnchoredIslandId));
     }
     #endregion
 }

--- a/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginLaser.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/Plugins/ArtifactTBPluginLaser.cs
@@ -78,7 +78,8 @@ public class ArtifactTBPluginLaser : ArtifactTBPlugin
         button.plugins.Add(this);
         if(tileDict == null)
             tileDict = new();
-        tileDict.Add(button, this);
+        if(!tileDict.ContainsKey(button))
+            tileDict.Add(button, this);
         SaveSprites();
         ResetSprites();
         if(centerObject == LaserCenterObject.SOURCE)

--- a/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
+++ b/Slider/Assets/Scripts/UI/Artifact/UIArtifact.cs
@@ -840,7 +840,8 @@ public class UIArtifact : Singleton<UIArtifact>
     {
         foreach (ArtifactTileButton b in buttons)
         {
-            b.Flicker(1);
+            if(b.gameObject.activeSelf)
+                b.Flicker(1);
         }
     }
 

--- a/Slider/Assets/Sprites/Items/breadge.png.meta
+++ b/Slider/Assets/Sprites/Items/breadge.png.meta
@@ -12,7 +12,7 @@ TextureImporter:
       213: 7010415914169473776
     second: breadge_2
   externalObjects: {}
-  serializedVersion: 11
+  serializedVersion: 12
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -29,11 +29,12 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
+    flipGreenChannel: 0
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
-  ignoreMasterTextureLimit: 0
+  ignoreMipmapLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -72,6 +73,8 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 1
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
@@ -83,6 +86,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
@@ -95,6 +99,20 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
@@ -109,7 +127,7 @@ TextureImporter:
         width: 16
         height: 16
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -129,8 +147,8 @@ TextureImporter:
         y: 0
         width: 16
         height: 16
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1875}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -150,8 +168,8 @@ TextureImporter:
         y: 0
         width: 16
         height: 16
-      alignment: 0
-      pivot: {x: 0, y: 0}
+      alignment: 9
+      pivot: {x: 0.5, y: 0.1875}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -174,12 +192,11 @@ TextureImporter:
     weights: []
     secondaryTextures: []
     nameFileIdTable:
-      breadge_2: 7010415914169473776
       breadge_0: 5337187301908176870
       breadge_1: -7012639881341796598
-  spritePackingTag: 
+      breadge_2: 7010415914169473776
+  mipmapLimitGroupName: 
   pSDRemoveMatte: 0
-  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
-Desync items and lever count anchored tile of desync as desync
-anchored tile of desync store in magitech grid
-fixed oil serialization 
-fixed gem serialization
-fixed burger reflections
-fixed issue where you could enable gfuel without all gems
-fixed laser not rendering when hitting rocket
-fixed some laser render order issues
-fixed bug where attempting to put gem into machine caused NRE if sprites not loaded

## Related Task
<!--- What is the related trello task for this PR -->
https://trello.com/c/Z3NicWDb/561-me-when-more-magitech-bugs
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
looked at it

## Screenshots (if appropriate):
