### PR TITLE
Better NPC Pings

### DIFF
--- a/Slider/Assets/Scripts/NPCs/NPCDialogueContext.cs
+++ b/Slider/Assets/Scripts/NPCs/NPCDialogueContext.cs
@@ -98,7 +98,7 @@ internal class NPCDialogueContext : MonoBehaviourContextProvider<NPC>, IInteract
     public override void Start()
     {
         base.Start();
-        display.SetMessagePing(!CurrDchainIsEmpty());
+        display.SetMessagePing(ShouldShowPing());
     }
 
     public override void Update()
@@ -138,6 +138,7 @@ internal class NPCDialogueContext : MonoBehaviourContextProvider<NPC>, IInteract
 
     public void OnDialogueTriggerExit()
     {
+        display.SetMessagePing(ShouldShowPing());
         playerInDialogueTrigger = false;
 
         TryDeactivateDialogueBox(true);
@@ -146,7 +147,7 @@ internal class NPCDialogueContext : MonoBehaviourContextProvider<NPC>, IInteract
 
     public void OnConditionalsChanged()
     {
-        display.SetMessagePing(!CurrDchainIsEmpty());
+        display.SetMessagePing(ShouldShowPing());
 
         StartDialogueIfPlayerInTrigger();
     }
@@ -442,5 +443,10 @@ internal class NPCDialogueContext : MonoBehaviourContextProvider<NPC>, IInteract
     private bool CurrDchainIsEmpty()
     {
         return CurrDchain == null || CurrDchain.Count == 0;
+    }
+
+    private bool ShouldShowPing()
+    {
+        return !CurrDchainIsEmpty() && !context.CurrCond.isDialogueChainExhausted;
     }
 }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE BELOW PR TEMPLATE -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
That was easy.
NPCs show pings for any unread dialogue. Pings don't reappear when dconds revert, unless there was unread dialogue.  Pings re-appear when walking away from an npc if there is unread dialogue.

## Related Task
<!--- What is the related trello task for this PR -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
